### PR TITLE
a very basic setup, by no means the final setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # n-teaser
-n-card and o-card's replacement - better styles, simpler combinations &amp; a more basic templating
+n-card and o-card's replacement - better styles, simpler combinations &amp; more basic templating
+
+## Demos
+https://financial-times.github.io/n-teaser/demos

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="stylesheet" href="//build.origami.ft.com/v2/bundles/css?modules=o-card@^2.2.3,o-typography@^4.3.1" />
+		<link rel="stylesheet" href="style.css" />
+		<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+		<script src="//origami-build.ft.com/v2/bundles/js?modules=o-date@^2.2.1"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
+	</head>
+	<body>
+
+		<div id="opinion" class="card"></div>
+
+		<script src="script.js"></script>
+	</body>
+</html>

--- a/demos/script.js
+++ b/demos/script.js
@@ -1,0 +1,18 @@
+fetch('../templates/opinion.mustache')
+	.then(res => res.text())
+	.then(source => {
+	const template = Handlebars.compile(source);
+	const context = {
+		img: {
+			src: 'http://image.webservices.ft.com/v1/images/raw/fthead:mrs-moneypenny?source=origami&amp;width=60',
+			alt: 'demo image'
+		},
+		tag: 'Mrs Moneypenny',
+		heading: 'Japan sells negative yield 10-year bonds',
+		datetime: {
+			raw: '2016-02-29T12:35:48Z',
+			formatted: '2016-02-29T12:35:48Z'
+		}
+	};
+	document.querySelector('#opinion').innerHTML = template(context);
+});

--- a/demos/style.css
+++ b/demos/style.css
@@ -1,0 +1,4 @@
+.card {
+	margin: 1em;
+	width: 20em;
+}

--- a/templates/opinion.mustache
+++ b/templates/opinion.mustache
@@ -1,0 +1,12 @@
+<div class="o-card o-card--opinion o-card--image-" data-o-component="o-card">
+	<div class="o-card__content">
+		<div class="o-card__meta">
+				<div class="o-card__meta-image o-card__meta-image--rounded">
+					<img src="{{{img.src}}}" alt="{{img.alt}}"></img>
+				</div>
+			<a href="#" class="o-card__tag">{{tag}}</a>
+		</div>
+		<h2 class="o-card__heading"><a href="#">{{heading}}</a></h2>
+			<time data-o-component="o-date" class="o-date o-card__timestamp" datetime="{{datetime.raw}}">{{datetime.formatted}}</time>
+	</div>
+</div>


### PR DESCRIPTION
We've been making progress with the templating work. We're kind of struck around `n-card`, as we don't want to use it - it's mighty and very difficult to port to Handlebars/ES6 template strings.

I'm suggesting that, for now, we just create two Handlebars templates (opinion & article) from `o-card` and put them in a new `n-teaser`.  Then over time we all can update/replace these as we make progress.