### PR TITLE
Add: data model query fragments

### DIFF
--- a/data_model/fragments.js
+++ b/data_model/fragments.js
@@ -52,19 +52,20 @@ module.exports = {
 		}
 	`,
 	teaserHeavy: `
-		fragment TeaserRelatedContent on Content {
+		fragment TeaserHeavy on Content {
 			storyPackage(limit: 3) {
 				type: __typename
 				relativeUrl
 				isPremium
 				title
 			}
-			primaryThemeTag {
+			primaryTag {
 				latestContent(limit: 4) {
 					type: __typename
 					relativeUrl
 					isPremium
 					title
+					id
 				}
 			}
 		}

--- a/data_model/fragments.js
+++ b/data_model/fragments.js
@@ -20,18 +20,21 @@ module.exports = {
 	`,
 	teaserLight: `
 		fragment TeaserLight on Content {
-			idV1
+			id
 			teaserTag {
 				prefLabel
 				relativeUrl
 			}
-			genreTag(only: ["analysis"]) {
+			genreTag(only: ["Analysis"]) {
 				prefLabel
 			}
 			primaryBrandTag {
 				prefLabel
 				relativeUrl
-				attributes
+				attributes(only: ["headshot"]) {
+					key
+					value
+				}
 			}
 		}
 	`,

--- a/data_model/fragments.js
+++ b/data_model/fragments.js
@@ -1,0 +1,69 @@
+module.exports = {
+	liveBlog: `
+		fragment LiveBlogInfo on LiveBlog {
+			status
+			updates(limit: 1) {
+				date
+				text
+			}
+		}
+	`,
+	teaserExtraLight: `
+		fragment TeaserExtraLight on Content {
+			type: __typename
+			isPremium
+			relativeUrl
+			title
+			publishedDate
+			initialPublishedDate
+		}
+	`,
+	teaserLight: `
+		fragment TeaserLight on Content {
+			idV1
+			teaserTag {
+				prefLabel
+				relativeUrl
+			}
+			genreTag(only: ["analysis"]) {
+				prefLabel
+			}
+			primaryBrandTag {
+				prefLabel
+				relativeUrl
+				attributes
+			}
+		}
+	`,
+	teaserStandard: `
+		fragment TeaserStandard on Content {
+			standfirst
+			mainImage {
+				title
+				description
+				url
+				width
+				height
+				ratio
+			}
+		}
+	`,
+	teaserHeavy: `
+		fragment TeaserRelatedContent on Content {
+			storyPackage(limit: 3) {
+				type: __typename
+				relativeUrl
+				isPremium
+				title
+			}
+			primaryThemeTag {
+				latestContent(limit: 4) {
+					type: __typename
+					relativeUrl
+					isPremium
+					title
+				}
+			}
+		}
+	`
+};

--- a/main.js
+++ b/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	fragments: require('./data_model/fragments')
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/n-teaser",
   "version": "0.0.0",
   "description": "n-card’s replacement: improved styles, simpler combinations, more basic templating",
-  "main": "",
+  "main": "main.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Financial-Times/n-teaser.git"


### PR DESCRIPTION
In building the data model for the n-teaser, it became pretty obvious that the model is tied to the template.

So I thought it would be an idea to have these data query fragments hosted in the n-teaser.

They can then be imported by any client app that wants to extract data for for presentation in a teaser.

This means that any changes to the template and data model can be done in one module together and propagated easily, without having to do releases of each client app.

However it does mean that it needs to be an NPM module to enable the requiring of the data fragments.

Client app would do;

`const fragments = require(n-teaser).fragments` or
`import {fragments} from n-teaser` for the hipsters.
