### PR TITLE
Add `referrerTracking` (& some data-trackables)

### DIFF
--- a/templates/extra-light.html
+++ b/templates/extra-light.html
@@ -1,7 +1,7 @@
 <div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser">
 	<div class="o-teaser__content">
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
 		{{#if lastPublished}}

--- a/templates/extra-light.html
+++ b/templates/extra-light.html
@@ -1,4 +1,4 @@
-<div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser">
+<div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 	<div class="o-teaser__content">
 		<h2 class="o-teaser__heading">
 			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>

--- a/templates/heavy.html
+++ b/templates/heavy.html
@@ -10,7 +10,7 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
 		{{#if summary}}

--- a/templates/heavy.html
+++ b/templates/heavy.html
@@ -1,6 +1,7 @@
 <div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 	<div class="o-teaser__content">
 		<div class="o-teaser__meta">
+			{{!-- This #tag/#brand syntax handles single objects *and* arrays of objects. There could be multiple brands, or in myFT pages, multiple tags --}}
 			{{#brand}}
 				<a href="{{{url}}}" class="o-teaser__tag" data-trackable="primary-tag">{{name}}</a>
 			{{/brand}}

--- a/templates/light.html
+++ b/templates/light.html
@@ -1,7 +1,7 @@
 <div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser">
 	<div class="o-teaser__content">
 		<div class="o-teaser__meta">
-			{{!-- This handles tag objects *and* an array of tag objects, due to myFT’s potential multiple topics in its stream views --}}
+			{{!-- This #tag/#brand syntax handles single objects *and* arrays of objects. There could be multiple brands, or in myFT pages, multiple tags --}}
 			{{#brand}}
 				<a href="{{{url}}}" class="o-teaser__tag" data-trackable="primary-tag">{{name}}</a>
 			{{/brand}}

--- a/templates/light.html
+++ b/templates/light.html
@@ -1,4 +1,4 @@
-<div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser">
+<div class="o-teaser {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 	<div class="o-teaser__content">
 		<div class="o-teaser__meta">
 			{{!-- This #tag/#brand syntax handles single objects *and* arrays of objects. There could be multiple brands, or in myFT pages, multiple tags --}}

--- a/templates/light.html
+++ b/templates/light.html
@@ -11,7 +11,7 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
 		{{#if lastPublished}}

--- a/templates/standard.html
+++ b/templates/standard.html
@@ -10,7 +10,7 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
 		{{#if summary}}

--- a/templates/standard.html
+++ b/templates/standard.html
@@ -1,6 +1,7 @@
 <div class="o-teaser  {{#if mod}}o-teaser--{{mod}}{{/if}} {{#if size}}o-teaser--{{size}}{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 	<div class="o-teaser__content">
 		<div class="o-teaser__meta">
+			{{!-- This #tag/#brand syntax handles single objects *and* arrays of objects. There could be multiple brands, or in myFT pages, multiple tags --}}
 			{{#brand}}
 				<a href="{{{url}}}" class="o-teaser__tag" data-trackable="primary-tag">{{name}}</a>
 			{{/brand}}


### PR DESCRIPTION
myFT links use the `referrerTracking` property to append query-string params/hashes to article URLs.

/cc @adgad 