### PR TITLE
update templates to match fragments

### DIFF
--- a/templates/extra-light.html
+++ b/templates/extra-light.html
@@ -1,11 +1,11 @@
 <div class="o-teaser{{#mods}} o-teaser--{{this}}{{/mods}}" data-o-component="o-teaser" data-trackable="teaser">
 	<div class="o-teaser__content">
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 	</div>
 </div>

--- a/templates/heavy.html
+++ b/templates/heavy.html
@@ -14,15 +14,15 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
-		{{#if summary}}
-			<p class="o-teaser__standfirst">{{summary}}</p>
+		{{#if standfirst}}
+			<p class="o-teaser__standfirst">{{standfirst}}</p>
 		{{/if}}
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 
 		{{#actions}}

--- a/templates/light.html
+++ b/templates/light.html
@@ -18,8 +18,8 @@
 			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 
 		{{#actions}}

--- a/templates/standard.html
+++ b/templates/standard.html
@@ -14,16 +14,16 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
 
-		{{#if summary}}
-			<p class="o-teaser__standfirst">{{summary}}</p>
+		{{#if standfirst}}
+			<p class="o-teaser__standfirst">{{standfirst}}</p>
 		{{/if}}
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 
 		{{#actions}}

--- a/templates/top-story-heavy.html
+++ b/templates/top-story-heavy.html
@@ -14,15 +14,15 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
-		{{#if summary}}
-			<p class="o-teaser__standfirst">{{summary}}</p>
+		{{#if standfirst}}
+			<p class="o-teaser__standfirst">{{standfirst}}</p>
 		{{/if}}
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 
 		{{#actions}}

--- a/templates/top-story-standard.html
+++ b/templates/top-story-standard.html
@@ -14,15 +14,15 @@
 		</div>
 
 		<h2 class="o-teaser__heading">
-			<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
+			<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{title}}</a>
 		</h2>
 
-		{{#if summary}}
-			<p class="o-teaser__standfirst">{{summary}}</p>
+		{{#if standfirst}}
+			<p class="o-teaser__standfirst">{{standfirst}}</p>
 		{{/if}}
 
-		{{#if lastPublished}}
-			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{lastPublished}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}</time>
+		{{#if publishedDate}}
+			<time data-o-component="o-date" class="o-date o-teaser__timestamp" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		{{/if}}
 
 		{{#actions}}


### PR DESCRIPTION
Matched up (some of) properties expected by template with n-teaser fragments

`lastPublished` -> `publishedDate`
`summary` -> `standfirst`
`url` -> `relativeUrl`