### PR TITLE
Add: isOpinion to data fragments for light teaser

### DIFF
--- a/data_model/fragments.js
+++ b/data_model/fragments.js
@@ -36,6 +36,7 @@ module.exports = {
 					value
 				}
 			}
+			isOpinion
 		}
 	`,
 	teaserStandard: `


### PR DESCRIPTION
tells us whether a piece of content is of genre opinion to be used for styling color of tag.