### PR TITLE
Add: promotional title to data fragments

### DIFF
--- a/data_model/fragments.js
+++ b/data_model/fragments.js
@@ -14,6 +14,7 @@ module.exports = {
 			isPremium
 			relativeUrl
 			title
+			promotionalTitle
 			publishedDate
 			initialPublishedDate
 		}
@@ -63,6 +64,7 @@ module.exports = {
 				relativeUrl
 				isPremium
 				title
+				promotionalTitle
 			}
 			primaryTag {
 				latestContent(limit: 4) {
@@ -70,6 +72,7 @@ module.exports = {
 					relativeUrl
 					isPremium
 					title
+					promotionalTitle
 					id
 				}
 			}


### PR DESCRIPTION
To make the shorter (promotional) title available to n-teasers