### PR TITLE
Fix tinting

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -1,7 +1,7 @@
 const ONE_HOUR = 1000 * 60 * 60;
 const MAX_RELATED_CONTENT = 3;
 const HEADSHOT_BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw/';
-const HEADSHOT_URL_PARAMS = '?source=next&fit=scale-down&compression=best&width=75&tint=054593,fff1e0';
+const HEADSHOT_URL_PARAMS = '?source=next&fit=scale-down&compression=best&width=75&tint=054593,d6d5d3';
 const TEMPLATES_WITH_HEADSHOTS = ['light','standard','lifestyle'];
 const TEMPLATES_WITH_IMAGES = ['heavy', 'top-story-heavy','lifestyle'];
 const LIVEBLOG_MAPPING = {

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -279,7 +279,7 @@ describe('Teaser Presenter', () => {
 
 		it('returns the full headshot file url and author name when a headshot exists', () => {
 			subject = new Presenter(articleOpinionAuthorFixture);
-			expect(subject.headshot.src).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/fthead:gideon-rachman?source=next&fit=scale-down&compression=best&width=75&tint=054593,fff1e0');
+			expect(subject.headshot.src).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/fthead:gideon-rachman?source=next&fit=scale-down&compression=best&width=75&tint=054593,d6d5d3');
 			expect(subject.headshot.alt).to.equal('Gideon Rachman');
 		});
 


### PR DESCRIPTION
For some headshots, especially those with very light hair or high
contrast, this tinting param makes the head appear like a set of
floating eyes.

I sat down with Sue and we found a better color which means even people
with very light hair photographed at high contrast can still be made
out.

Before:
![screen shot 2016-12-05 at 12 04 57](https://cloud.githubusercontent.com/assets/68009/20887625/5baf6f44-baf3-11e6-83d0-dffa68d7dd80.png)

After (tested with all headshots)
![screen shot 2016-12-05 at 13 49 37](https://cloud.githubusercontent.com/assets/68009/20887636/6576327e-baf3-11e6-84e9-a71bfe8da9ff.png)
![screen shot 2016-12-05 at 13 49 47](https://cloud.githubusercontent.com/assets/68009/20887638/65798654-baf3-11e6-9505-43c8ec9fa8f4.png)
![screen shot 2016-12-05 at 13 49 57](https://cloud.githubusercontent.com/assets/68009/20887637/65765c9a-baf3-11e6-9ddd-b69a2f76fe71.png)
![screen shot 2016-12-05 at 13 50 12](https://cloud.githubusercontent.com/assets/68009/20887635/65762932-baf3-11e6-9259-20b3532f54e7.png)
![screen shot 2016-12-05 at 13 50 20](https://cloud.githubusercontent.com/assets/68009/20887634/65762112-baf3-11e6-9a2a-e1735b2716b8.png)
