### PR TITLE
Amend: allow pass through of display parameters to templates

### DIFF
--- a/templates/partials/display-tag.html
+++ b/templates/partials/display-tag.html
@@ -1,16 +1,18 @@
-<div class="o-teaser__meta">
-	{{#if @nTeaserPresenter.displayTag}}
-		<a href="{{{@nTeaserPresenter.displayTag.relativeUrl}}}" class="o-teaser__tag" data-trackable="primary-tag">
-			{{#if @nTeaserPresenter.genrePrefix}}
-				<strong>{{@nTeaserPresenter.genrePrefix}} </strong>
-			{{/if}}
-			{{@nTeaserPresenter.displayTag.prefLabel}}
-		</a>
-	{{/if}}
-	{{#with @nTeaserPresenter.formattedDuration}}
-		<p class="o-teaser__duration">{{this}}min</p>
-	{{/with}}
-	{{#if advertiser}}
-		<span class="o-teaser__promoted-prefix">{{promotedByPrefix}}</span> by <span class="o-teaser__promoted-by">{{advertiser}}</span>
-	{{/if}}
-</div>
+{{#unless noTag}}
+	<div class="o-teaser__meta">
+		{{#if @nTeaserPresenter.displayTag}}
+			<a href="{{{@nTeaserPresenter.displayTag.relativeUrl}}}" class="o-teaser__tag" data-trackable="primary-tag">
+				{{#if @nTeaserPresenter.genrePrefix}}
+					<strong>{{@nTeaserPresenter.genrePrefix}} </strong>
+				{{/if}}
+				{{@nTeaserPresenter.displayTag.prefLabel}}
+			</a>
+		{{/if}}
+		{{#with @nTeaserPresenter.formattedDuration}}
+			<p class="o-teaser__duration">{{this}}min</p>
+		{{/with}}
+		{{#if advertiser}}
+			<span class="o-teaser__promoted-prefix">{{promotedByPrefix}}</span> by <span class="o-teaser__promoted-by">{{advertiser}}</span>
+		{{/if}}
+	</div>
+{{/unless}}

--- a/templates/partials/related-content.html
+++ b/templates/partials/related-content.html
@@ -1,9 +1,11 @@
-{{#if @nTeaserPresenter.relatedContent}}
-	<ul class="o-teaser__related">
-		{{#each @nTeaserPresenter.relatedContent}}
-			<li class="o-teaser__related-item">
-				<a data-trackable="related" href="{{relativeUrl}}">{{title}}</a>
-			</li>
-		{{/each}}
-	</ul>
-{{/if}}
+{{#unless noRelatedContent}}
+	{{#if @nTeaserPresenter.relatedContent}}
+		<ul class="o-teaser__related">
+			{{#each @nTeaserPresenter.relatedContent}}
+				<li class="o-teaser__related-item">
+					<a data-trackable="related" href="{{relativeUrl}}">{{title}}</a>
+				</li>
+			{{/each}}
+		</ul>
+	{{/if}}
+{{/unless}}


### PR DESCRIPTION
cc: @keirog 

In some views, eg. front page big story, there is a need to suppress certain standard template features (eg. tag or related content).

In pre v1.0.0 these were done by setting tag or relatedContent to false. However in the new presenter model the data no longer works in a way that is compatible with that.

Hence partials will take arguments of noTag or noRelatedContent to suppress those elements from presentation.