### PR TITLE
Amend: display tag logic for author & brand combos

### DIFF
--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -25,10 +25,14 @@ module.exports = {
 			primaryBrandTag {
 				prefLabel
 				relativeUrl
+				taxonomy
 				attributes(only: ["headshot"]) {
 					key
 					value
 				}
+			}
+			authorTags(limit: 1) {
+				prefLabel
 			}
 			isOpinion
 		}

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -10,6 +10,19 @@ const LIVEBLOG_MAPPING = {
 	closed: 'liveblog closed'
 };
 
+const brandAuthorDouble = (data) => {
+	if (
+		data.primaryBrandTag &&
+		data.primaryBrandTag.taxonomy === 'brand' &&
+		data.authorTags &&
+		data.authorTags.length &&
+		data.isOpinion === true
+	) {
+		return true;
+	}
+		return false;
+};
+
 const TeaserPresenter = class TeaserPresenter {
 
 	constructor (data) {
@@ -47,11 +60,20 @@ const TeaserPresenter = class TeaserPresenter {
 			(this.data.streamId === this.data.primaryBrandTag.idV1)) {
 			return this.data.teaserTag || null;
 		}
+		if (brandAuthorDouble(this.data) === true) {
+			return this.data.authorTags[0];
+		}
 		return this.data.primaryBrandTag || this.data.teaserTag || null;
 	}
 
 	//returns genre prefix
 	get genrePrefix () {
+		if (brandAuthorDouble(this.data) === true) {
+			// HACK to dedupe authors who are also brands
+			if (this.data.primaryBrandTag.prefLabel !== this.data.authorTags[0].prefLabel) {
+				return this.data.primaryBrandTag.prefLabel;
+			}
+		}
 		if (!this.data.genreTag || this.data.primaryBrandTag === this.displayTag) {
 			return null;
 		}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -184,6 +184,29 @@ describe('Teaser Presenter', () => {
 
 		});
 
+		context('when it is both a brand and an opinion / author', () => {
+
+			const primaryBrandTag = { primaryBrandTag: { prefLabel: 'brandName', taxonomy: 'brand' } };
+			const primaryBrandTagDupe = { primaryBrandTag: { prefLabel: 'authorName', taxonomy: 'brand' } };
+			const authorTags = { authorTags: [ { prefLabel: 'authorName', taxonomy: 'author' } ] };
+			const isOpinion = { isOpinion: true }
+
+			it('returns the brand as genrePrefix and author as displayTag', () => {
+				const content = Object.assign({}, primaryBrandTag, authorTags, isOpinion);
+				subject = new Presenter(content);
+				expect(subject.genrePrefix).to.equal(primaryBrandTag.primaryBrandTag.prefLabel);
+				expect(subject.displayTag).to.deep.equal(authorTags.authorTags[0]);
+			});
+
+			it('returns only the author as displayTag if brand and author are the same', () => {
+				const content = Object.assign({}, primaryBrandTagDupe, authorTags, isOpinion);
+				subject = new Presenter(content);
+				expect(subject.genrePrefix).to.be.null;
+				expect(subject.displayTag).to.deep.equal(authorTags.authorTags[0]);
+			});
+
+		});
+
 	});
 
 	context('timeStatus', () => {


### PR DESCRIPTION
Editorial request for when a piece of content is an opinion piece and has a brand, that it should display the brand as the genre prefix and the author as the main (clickable tag).

Examples;

![screen shot 2016-12-05 at 16 59 55](https://cloud.githubusercontent.com/assets/8938227/20894242/86ac3e16-bb0c-11e6-8423-c58e491ce64f.png)
