### PR TITLE
Fix: pass relativeUrl through for author tags

### DIFF
--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -33,6 +33,7 @@ module.exports = {
 			}
 			authorTags(limit: 1) {
 				prefLabel
+				relativeUrl
 			}
 			isOpinion
 		}


### PR DESCRIPTION
Otherwise it just links to the home page when we have the brand author combo.