### PR TITLE
Amend: remove headshot class when noHeadshot attribute passed

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -44,6 +44,7 @@ const TeaserPresenter = class TeaserPresenter {
 	get classModifiers () {
 		const mods = this.data.mods || [];
 		if (
+			!this.data.noHeadshot &&
 			this.headshot &&
 			TEMPLATES_WITH_HEADSHOTS.some(template => template === this.data.template)
 		) {

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -48,6 +48,12 @@ describe('Teaser Presenter', () => {
 				expect(subject.classModifiers.length).to.equal(0);
 			});
 
+			it('does not add a modifier if noHeadshot parameter passed through', () => {
+				const content = Object.assign({noHeadshot: true}, articleOpinionAuthorFixture, {template: 'standard'});
+				subject = new Presenter(content);
+				expect(subject.classModifiers).to.not.include('has-headshot');
+			});
+
 		});
 
 		context('has-image', () => {


### PR DESCRIPTION
it removes the headshot already, but also needs to remove the class.