### PR TITLE
Prevent: Tab focus on images

### DIFF
--- a/templates/partials/image.html
+++ b/templates/partials/image.html
@@ -1,6 +1,7 @@
+<!-- TODO: This file to be deprecated -->
 {{#if image}}
 	<div class="o-teaser__image-container">
-		<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true" tabindex="-1">
+		<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true">
 		{{#ifEquals lazyLoad false}}
 			{{#nImagePresenter src=image.src srcSet=image.url placeholder=image.ratio colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image"}}
 				{{> n-image/templates/image}}

--- a/templates/partials/image.html
+++ b/templates/partials/image.html
@@ -1,6 +1,6 @@
 {{#if image}}
 	<div class="o-teaser__image-container">
-		<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true">
+		<a href="{{{url}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true" tabindex="-1">
 		{{#ifEquals lazyLoad false}}
 			{{#nImagePresenter src=image.src srcSet=image.url placeholder=image.ratio colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image"}}
 				{{> n-image/templates/image}}

--- a/templates/partials/main-image.html
+++ b/templates/partials/main-image.html
@@ -1,6 +1,6 @@
 {{#if mainImage}}
 	<div class="o-teaser__image-container">
-		<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true">
+		<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="image" aria-hidden="true" tabindex="-1">
 			{{#ifEquals lazyLoad false}}
 				{{#nImagePresenter srcSet=mainImage.url placeholder=mainImage.ratio colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image"}}
 					{{> n-image/templates/image}}


### PR DESCRIPTION
@i-like-robots @lc512k 

Addresses issue in DAC report issue tracking document:
```
DAC-USER-KO-T10-05
Science and Environment
Images getting focus where they shouldn’t or should have a focus ring, as user tabs through stories
```

While we have the headline (which links to the same place), there does not seem to be any purpose in having tab focus on the image as well, so have opted for the former of the suggestions, but am happy to be proven wrong with exceptions.