### PR TITLE
Enhancement: enable toggle between promotional and standard title

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -175,6 +175,14 @@ const TeaserPresenter = class TeaserPresenter {
 		return LIVEBLOG_MAPPING[this.data.status.toLowerCase()].labelModifier;
 	}
 
+	// returns title either standard or promotional based on flag
+	get displayTitle () {
+		if (this.data.flags && this.data.flags.teaserUsePromotionalTitle && this.data.promotionalTitle) {
+			return this.data.promotionalTitle;
+		}
+		return this.data.title;
+	}
+
 	//returns prefix for timestamp (null / 'new' / 'updated')
 	timeStatus () {
 		const now = Date.now();

--- a/templates/extra-light.html
+++ b/templates/extra-light.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='extra-light' mods=mods}}
+{{#nTeaserPresenter @this template='extra-light' mods=mods flags=@root.flags}}
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 

--- a/templates/heavy.html
+++ b/templates/heavy.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='heavy' mods=mods}}
+{{#nTeaserPresenter @this template='heavy' mods=mods flags=@root.flags}}
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 

--- a/templates/lifestyle.html
+++ b/templates/lifestyle.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='lifestyle' mods=mods}}
+{{#nTeaserPresenter @this template='lifestyle' mods=mods flags=@root.flags}}
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 
 		{{> n-teaser/templates/partials/main-image}}

--- a/templates/light.html
+++ b/templates/light.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='light' mods=mods}}
+{{#nTeaserPresenter @this template='light' mods=mods flags=@root.flags}}
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -1,5 +1,5 @@
 <h3 class="o-teaser__heading">
-	<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{{title}}}</a>
+	<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{@nTeaserPresenter.displayTitle}}</a>
 	{{#if isPremium}}
 		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
 	{{/if}}

--- a/templates/standard.html
+++ b/templates/standard.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='standard' mods=mods}}
+{{#nTeaserPresenter @this template='standard' mods=mods flags=@root.flags}}
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 
 		<div class="o-teaser__content">

--- a/templates/top-story-heavy.html
+++ b/templates/top-story-heavy.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='top-story-heavy' mods=mods}}
+{{#nTeaserPresenter @this template='top-story-heavy' mods=mods flags=@root.flags}}
 	<div class="o-teaser o-teaser--top-story o-teaser--landscape{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 

--- a/templates/top-story-standard.html
+++ b/templates/top-story-standard.html
@@ -1,4 +1,4 @@
-{{#nTeaserPresenter @this template='top-story-standard' mods=mods}}
+{{#nTeaserPresenter @this template='top-story-standard' mods=mods flags=@root.flags}}
 	<div class="o-teaser o-teaser--top-story o-teaser--standalone{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -405,4 +405,31 @@ describe('Teaser Presenter', () => {
 
 	});
 
+	context('displayTitle', () => {
+
+		const promotionalTitle = { promotionalTitle: 'promotional' };
+		const title = { title: 'title'};
+		const flagOn = { flags: { teaserUsePromotionalTitle: true } };
+		const flagOff = { flags: { teaserUsePromotionalTitle: false } };
+
+		it('returns the promotional title if it exists and flag is on', () => {
+			const content = Object.assign({}, title, promotionalTitle, flagOn);
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('promotional');
+		});
+
+		it('returns the title if flag is off', () => {
+			const content = Object.assign({}, title, promotionalTitle, flagOff);
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+		it('returns the title if flag is on and no promotional title exists', () => {
+			const content = Object.assign({}, title, flagOn);
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+	});
+
 });


### PR DESCRIPTION
can use flag `teaserUsePromotionalTitle` to toggle between shorter promotional title and standard title in headline across all teasers across the site.