### PR TITLE
don't escape characters in the title and standfirst

### DIFF
--- a/templates/partials/standfirst.html
+++ b/templates/partials/standfirst.html
@@ -1,3 +1,3 @@
 {{#if standfirst}}
-	<p class="o-teaser__standfirst">{{standfirst}}</p>
+	<p class="o-teaser__standfirst">{{{standfirst}}}</p>
 {{/if}}

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -1,5 +1,5 @@
 <h3 class="o-teaser__heading">
-	<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{@nTeaserPresenter.displayTitle}}</a>
+	<a href="{{{relativeUrl}}}{{{referrerTracking}}}" data-trackable="main-link">{{{@nTeaserPresenter.displayTitle}}}</a>
 	{{#if isPremium}}
 		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
 	{{/if}}


### PR DESCRIPTION
Fixes a bug where the title and standfirst on a related article card would double encode the ampersand from `&` > `&amp;` > `&amp;amp;`. Which would render as `&amp;` in the browser
