### PR TITLE
lazy loading headshots

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -5,6 +5,7 @@ const hyphenatePascalCase = require('../utils/hyphenate-pascal-case');
 const ONE_HOUR = 1000 * 60 * 60;
 const MAX_RELATED_CONTENT = 3;
 const HEADSHOT_BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw/';
+const HEADSHOT_URL_PARAMETERS = '?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3';
 const HEADSHOT_WIDTH = 75;
 const TEMPLATES_WITH_HEADSHOTS = ['light','standard','lifestyle'];
 const TEMPLATES_WITH_IMAGES = ['heavy', 'top-story-heavy','lifestyle'];
@@ -164,7 +165,7 @@ const TeaserPresenter = class TeaserPresenter {
 
 		if (fileName) {
 			return {
-				url: `${HEADSHOT_BASE_URL}${fileName}?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3`,
+				url: `${HEADSHOT_BASE_URL}${fileName}${HEADSHOT_URL_PARAMETERS}`,
 				width: HEADSHOT_WIDTH,
 				height: HEADSHOT_WIDTH,
 				sizes: HEADSHOT_WIDTH,

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -5,7 +5,7 @@ const hyphenatePascalCase = require('../utils/hyphenate-pascal-case');
 const ONE_HOUR = 1000 * 60 * 60;
 const MAX_RELATED_CONTENT = 3;
 const HEADSHOT_BASE_URL = 'https://www.ft.com/__origami/service/image/v2/images/raw/';
-const HEADSHOT_URL_PARAMS = '?source=next&fit=scale-down&compression=best&width=75&tint=054593,d6d5d3';
+const HEADSHOT_WIDTH = 75;
 const TEMPLATES_WITH_HEADSHOTS = ['light','standard','lifestyle'];
 const TEMPLATES_WITH_IMAGES = ['heavy', 'top-story-heavy','lifestyle'];
 const LIVEBLOG_MAPPING = {
@@ -161,10 +161,15 @@ const TeaserPresenter = class TeaserPresenter {
 		) {
 			fileName = this.data.authorTags[0].attributes[0].value;
 		}
+
 		if (fileName) {
 			return {
-				src: `${HEADSHOT_BASE_URL}${fileName}${HEADSHOT_URL_PARAMS}`,
-				alt: this.data.primaryBrandTag.prefLabel
+				url: `${HEADSHOT_BASE_URL}${fileName}?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3`,
+				width: HEADSHOT_WIDTH,
+				height: HEADSHOT_WIDTH,
+				sizes: HEADSHOT_WIDTH,
+				widths: [HEADSHOT_WIDTH, 2 * HEADSHOT_WIDTH],
+				alt: `Photo of ${this.data.primaryBrandTag.prefLabel}`
 			};
 		} else {
 			return null;

--- a/templates/partials/headshot.html
+++ b/templates/partials/headshot.html
@@ -1,5 +1,25 @@
 {{#unless noHeadshot}}
 	{{#with @nTeaserPresenter.headshot}}
-		<img src="{{src}}" alt="Photo of {{alt}}" class="o-teaser__headshot">
+		{{#nImagePresenter
+				srcSet=url
+				width=width
+				height=height
+				sizes=sizes
+				widths=widths
+				lazyLoad=true
+				alt=alt
+			}}
+
+				{{#with image.imgAttrs}}
+					{{!HACK: n-image needs refactoring to alow applying lazy, responsive images without the image wrapper and classes }}
+					<img
+					width="75px"
+					height="75px"
+					{{#if data-srcset}} data-srcset="{{data-srcset}}"{{/if}}
+					{{#if sizes}} sizes="{{sizes}}"{{/if}}
+					{{#if role}} role="{{role}}"{{/if}}
+					alt="{{alt}}" class="o-teaser__headshot n-image--lazy-loading"/>
+				{{/with}}
+		{{/nImagePresenter}}
 	{{/with}}
 {{/unless}}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -380,8 +380,8 @@ describe('Teaser Presenter', () => {
 
 		it('returns the full headshot file url and author name when a headshot exists', () => {
 			subject = new Presenter(articleOpinionAuthorFixture);
-			expect(subject.headshot.src).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/fthead:gideon-rachman?source=next&fit=scale-down&compression=best&width=75&tint=054593,d6d5d3');
-			expect(subject.headshot.alt).to.equal('Gideon Rachman');
+			expect(subject.headshot.url).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/fthead:gideon-rachman?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3');
+			expect(subject.headshot.alt).to.equal('Photo of Gideon Rachman');
 		});
 
 		it('returns null when headshot does not exist', () => {
@@ -398,7 +398,7 @@ describe('Teaser Presenter', () => {
 			it('returns a headshot when the author has one', () => {
 				const content = Object.assign({}, primaryBrandTag, authorTags, isOpinion);
 				subject = new Presenter(content);
-				expect(subject.headshot.src).to.include('author-name');
+				expect(subject.headshot.url).to.include('author-name');
 			});
 
 		});


### PR DESCRIPTION
@andygnewman 

This is _sooo_ hacky. I reckon a new major version of n-image will be in order soon (loads of react stuff to remove anyway) and fixing
- tight coupling of lazy loading & responsiveness with n-image base classes
- not all properties always get propagated through the image presenter and on to the template (e.g. width/height)

But for now, it fixes a perf regression on the home page, so would still like to get this out and raise a tech debt issue 