### PR TITLE
Amend: Promoted content prefix

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -197,7 +197,7 @@ const TeaserPresenter = class TeaserPresenter {
 
 	get advertiserPrefix () {
 		if (this.data.advertiser) {
-			if (this.data.type === 'smartmatch') {
+			if (this.data.type === 'promoted-content') {
 				return ' paid for by ';
 			} else {
 				return ' by ';

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -195,6 +195,18 @@ const TeaserPresenter = class TeaserPresenter {
 		return this.data.title;
 	}
 
+	get advertiserPrefix () {
+		if (this.data.advertiser) {
+			if (this.data.type === 'smartmatch') {
+				return ' paid for by ';
+			} else {
+				return ' by ';
+			}
+		} else {
+			return '';
+		}
+	}
+
 	//returns prefix for timestamp (null / 'new' / 'updated')
 	timeStatus () {
 		const now = Date.now();

--- a/templates/partials/display-tag.html
+++ b/templates/partials/display-tag.html
@@ -17,7 +17,7 @@
 			<p class="o-teaser__duration">{{this}}min</p>
 		{{/with}}
 		{{#if advertiser}}
-			<span class="o-teaser__promoted-prefix">{{promotedByPrefix}}</span> by <span class="o-teaser__promoted-by">{{advertiser}}</span>
+			<span class="o-teaser__promoted-prefix">{{promotedByPrefix}}</span>{{@nTeaserPresenter.advertiserPrefix}}<span class="o-teaser__promoted-by">{{advertiser}}</span>
 		{{/if}}
 	</div>
 {{/unless}}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -279,10 +279,10 @@ describe('Teaser Presenter', () => {
 
 	context('advertiserPrefix', () => {
 
-		it('paid for by - when has an advertiser and type of smartmatch', () => {
+		it('paid for by - when has an advertiser and type of promoted content', () => {
 			const content = {
 				advertiser: 'Nikkei',
-				type: 'smartmatch'
+				type: 'promoted-content'
 			};
 			subject = new Presenter(content);
 			expect(subject.advertiserPrefix).to.equal(' paid for by ');

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -277,6 +277,38 @@ describe('Teaser Presenter', () => {
 
 	});
 
+	context('advertiserPrefix', () => {
+
+		context('has an advertiser and type of smartmatch', () => {
+			const content = {
+				advertiser: 'Nikkei',
+				type: 'smartmatch'
+			};
+
+			subject = new Presenter(content);
+			expect(subject.advertiserPrefix).to.equal(' paid for by ');
+		});
+
+		context('has an advertiser and type of paid post', () => {
+			const content = {
+				advertiser: 'Nikkei',
+				type: 'paid-post'
+			};
+
+			subject = new Presenter(content);
+			expect(subject.advertiserPrefix).to.equal(' by ');
+		});
+
+		context('does not have an advertiser and type is article', () => {
+			const content = {
+				type: 'article'
+			};
+
+			subject = new Presenter(content);
+			expect(subject.advertiserPrefix).to.equal('');
+		});
+	});
+
 	context('timeStatus', () => {
 
 		const FIFTY_NINE_MINUTES = 1000 * 60 * 59;

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -279,34 +279,32 @@ describe('Teaser Presenter', () => {
 
 	context('advertiserPrefix', () => {
 
-		context('has an advertiser and type of smartmatch', () => {
+		it('paid for by - when has an advertiser and type of smartmatch', () => {
 			const content = {
 				advertiser: 'Nikkei',
 				type: 'smartmatch'
 			};
-
 			subject = new Presenter(content);
 			expect(subject.advertiserPrefix).to.equal(' paid for by ');
 		});
 
-		context('has an advertiser and type of paid post', () => {
+		it('by - when has an advertiser and type of paid post', () => {
 			const content = {
 				advertiser: 'Nikkei',
 				type: 'paid-post'
 			};
-
 			subject = new Presenter(content);
 			expect(subject.advertiserPrefix).to.equal(' by ');
 		});
 
-		context('does not have an advertiser and type is article', () => {
+		it('blank - when does not have an advertiser and type is article', () => {
 			const content = {
 				type: 'article'
 			};
-
 			subject = new Presenter(content);
 			expect(subject.advertiserPrefix).to.equal('');
 		});
+
 	});
 
 	context('timeStatus', () => {


### PR DESCRIPTION
Currently both paid posts and promoted content share the same prefix of 'by' between the label and the advertiser name.

There is a business requirement for the promoted content to have a prefix of 'paid for by', where as paid post should retain the 'by' prefix.

Have implemented the logic for this in the presenter rather than the template.