### PR TITLE
update and remove n-ui

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
 		"tests"
 	],
 	"devDependencies": {
-		"n-ui": "^4.0.0",
+		"n-ui-foundations": "^1.0.0",
 		"o-teaser": "^1.3.2",
 		"o-labels": "^2.0.3",
 		"n-image": "^4.9.3"

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,4 +1,4 @@
-@import 'n-ui/main';
+@import 'n-ui-foundations/main';
 
 $o-labels-is-silent: false;
 @import 'o-labels/main';

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {},
   "devDependencies": {
     "@financial-times/n-express": "^17.20.2",
-    "@financial-times/n-ui": "^4.0.0",
     "bower": "^1.7.9",
     "chai": "^3.2.0",
     "chalk": "^1.1.3",


### PR DESCRIPTION
<img width="904" alt="screen shot 2017-05-16 at 14 46 38" src="https://cloud.githubusercontent.com/assets/3425322/26109201/ab6ec7f0-3a46-11e7-9c14-56a1648ac9d3.png">

cc @laurieboyes @debugwand @keirog, I've removed n-ui and swapped out for n-ui-foundations. Demos look fine and pa11y tests still run. I'm not entirely familiar with n-teaser, though, would you mind giving it a sanity check? Anything else need updating? 