### PR TITLE
Story package => Curated related content

### DIFF
--- a/demos/fixtures/fixtures.json
+++ b/demos/fixtures/fixtures.json
@@ -33,7 +33,7 @@
 			"ratio": 1.7777777777778,
 			"sourceParam": "n-teaser"
 		},
-		"storyPackage": [
+		"curatedRelatedContent": [
 
 		],
 		"primaryTag": {

--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -102,7 +102,7 @@ module.exports = {
 	`,
 	teaserTopStory: `
 		fragment TeaserTopStory on Content {
-			storyPackage(limit: 3) {
+			curatedRelatedContent(limit: 3) {
 				type: __typename
 				relativeUrl
 				isPremium

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -175,8 +175,8 @@ const TeaserPresenter = class TeaserPresenter {
 	// returns an array of content items related to the main article
 	get relatedContent () {
 		let relatedContent = [];
-		if (Array.isArray(this.data.storyPackage) && this.data.storyPackage.length > 0) {
-			relatedContent = this.data.storyPackage;
+		if (Array.isArray(this.data.curatedRelatedContent) && this.data.curatedRelatedContent.length > 0) {
+			relatedContent = this.data.curatedRelatedContent;
 		} else if (this.data.displayConcept && Array.isArray(this.data.displayConcept.latestContent)) {
 			relatedContent = this.data.displayConcept.latestContent.filter(content => content.id !== this.data.id);
 		}

--- a/tests/fixtures/article-brand-fixture.json
+++ b/tests/fixtures/article-brand-fixture.json
@@ -21,7 +21,7 @@
     "height": 1152,
     "ratio": 1.7777777777777777
   },
-  "storyPackage": [],
+  "curatedRelatedContent": [],
   "displayConcept": {
     "prefLabel": "FT View",
     "relativeUrl": "/comment/ft-view",

--- a/tests/fixtures/article-opinion-author-fixture.json
+++ b/tests/fixtures/article-opinion-author-fixture.json
@@ -26,7 +26,7 @@
     "height": 1152,
     "ratio": 1.7777777777777777
   },
-  "storyPackage": [],
+  "curatedRelatedContent": [],
   "displayConcept": {
     "prefLabel": "Global politics",
     "relativeUrl": "/topics/themes/Global_politics",

--- a/tests/fixtures/article-standard-fixture.json
+++ b/tests/fixtures/article-standard-fixture.json
@@ -17,7 +17,7 @@
     "height": 1152,
     "ratio": 1.7777777777777777
   },
-  "storyPackage": [
+  "curatedRelatedContent": [
     {
       "type": "Article",
       "relativeUrl": "/content/8ecc36d0-9f66-11e6-86d5-4e36b35c3550",

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -449,12 +449,12 @@ describe('Teaser Presenter', () => {
 
 	context('relatedContent', () => {
 
-		it('returns the story package when one exists', () => {
+		it('returns the curated related content when they exists', () => {
 			subject = new Presenter(articleStandardFixture);
-			expect(subject.relatedContent.map(item => item.data)).to.deep.equal(articleStandardFixture.storyPackage);
+			expect(subject.relatedContent.map(item => item.data)).to.deep.equal(articleStandardFixture.curatedRelatedContent);
 		});
 
-		it('returns latest content of display concept when no story package, current article filtered', () => {
+		it('returns latest content of display concept when no curated related content, current article filtered', () => {
 			subject = new Presenter(articleBrandFixture);
 			expect(subject.relatedContent.length).to.equal(3);
 			subject.relatedContent.map(content => {


### PR DESCRIPTION
I'll merge this into the `migrate_v2` branch once I get my next-api build passing.

(note: things might break in the transition)