### PR TITLE
Use new genre, brand and authors next-api fields

### DIFF
--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -35,7 +35,9 @@ module.exports = {
 				prefLabel
 				relativeUrl
 				id
-				headshot
+				headshot {
+					name
+				}
 			}
 		}
 	`,

--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -20,29 +20,23 @@ module.exports = {
 			firstPublishedDate
 			isEditorsChoice
 			canBeSyndicated
-			genreConcept(only: ["61d707b5-6fab-3541-b017-49b72de80772", "9c2af23a-ee61-303f-97e8-2026fb031bd5", "dc9332a7-453d-3b80-a53d-5a19579d9359", "b3ecdf0e-68bb-3303-8773-ec9c05e80234", "3094f0a9-1e1c-3ec3-b7e3-4d4885a826ed"]) {
+			isOpinion
+			genre {
+				id
 				prefLabel
 			}
-			brandConcept {
+			brand {
 				prefLabel
 				relativeUrl
 				directType
-				attributes(only: ["headshot"]) {
-					key
-					value
-				}
 				id
 			}
-			authorConcepts(limit: 1) {
+			authors {
 				prefLabel
 				relativeUrl
-				attributes(only: ["headshot"]) {
-					key
-					value
-				}
 				id
+				headshot
 			}
-			isOpinion
 		}
 	`,
 	teaserLight: `
@@ -85,7 +79,7 @@ module.exports = {
 						theme
 					}
 				}
-				brandConcept {
+				brand {
 					prefLabel
 					relativeUrl
 				}

--- a/src/presenters/package-teaser-presenter.js
+++ b/src/presenters/package-teaser-presenter.js
@@ -30,9 +30,9 @@ const TeaserPresenter = class TeaserPresenter {
 
 	//returns FT Series or Special Reports
 	get genrePrefix () {
-		if (this.data.brandConcept) {
-			if (this.data.brandConcept.prefLabel === 'Special Report' || this.data.brandConcept.prefLabel === 'FT Series') {
-				return this.data.brandConcept.prefLabel;
+		if (this.data.brand) {
+			if (this.data.brand.prefLabel === 'Special Report' || this.data.brand.prefLabel === 'FT Series') {
+				return this.data.brand.prefLabel;
 			}
 		}
 	}

--- a/templates/extra-light.html
+++ b/templates/extra-light.html
@@ -2,7 +2,7 @@
 	<div class="o-teaser{{#each @nTeaserPresenter.classModifiers}} o-teaser--{{this}}{{/each}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 
-			{{#ifSome isOpinion brandConcept}}
+			{{#ifSome isOpinion brand}}
 				{{> n-teaser/templates/partials/display-concept}}
 			{{/ifSome}}
 

--- a/tests/fixtures/article-brand-fixture.json
+++ b/tests/fixtures/article-brand-fixture.json
@@ -6,8 +6,8 @@
   "publishedDate": "2016-10-31T12:18:18Z",
   "firstPublishedDate": "2016-10-31T12:18:18Z",
   "id": "f61b93c8-9f5a-11e6-891e-abe238dee8e2",
-  "genreConcept": null,
-  "brandConcept": {
+  "genre": null,
+  "brand": {
     "prefLabel": "FT View",
     "relativeUrl": "/comment/ft-view",
     "attributes": []

--- a/tests/fixtures/article-opinion-author-fixture.json
+++ b/tests/fixtures/article-opinion-author-fixture.json
@@ -6,17 +6,15 @@
   "publishedDate": "2016-10-31T11:49:56Z",
   "firstPublishedDate": "2016-10-31T11:49:56Z",
   "id": "39da343a-9f4b-11e6-891e-abe238dee8e2",
-  "genreConcept": null,
-  "brandConcept": {
+  "isOpinion": true,
+  "genre": null,
+  "authors": [{
     "prefLabel": "Gideon Rachman",
     "relativeUrl": "/comment/columnists/gideonrachman",
-    "attributes": [
-      {
-        "key": "headshot",
-        "value": "fthead:gideon-rachman"
-      }
-    ]
-  },
+    "headshot": {
+        "name": "gideon-rachman"
+    }
+  }],
   "standfirst": null,
   "mainImage": {
     "title": "",

--- a/tests/fixtures/article-package-fixture.json
+++ b/tests/fixtures/article-package-fixture.json
@@ -9,7 +9,7 @@
 	"firstPublishedDate": "2017-04-09T08:23:47Z",
 	"isEditorsChoice": false,
 	"canBeSyndicated": "verify",
-	"genreConcept": null,
+	"genre": null,
 	"containedIn": [
 		{
 			"title": "Management’s missing women",
@@ -24,7 +24,7 @@
 				"directType": "http://www.ft.com/ontology/Topic",
 				"url": "https://www.ft.com/stream/3a34141d-e886-3c6f-8985-551ed91e994a"
 			},
-			"brandConcept": {
+			"brand": {
 				"idV1": "fb491676-5024-3111-a959-1fbce2fbecc1",
 				"prefLabel": "FT Series",
 				"taxonomy": "http://www.ft.com/ontology/product/Brand",

--- a/tests/fixtures/article-standard-fixture.json
+++ b/tests/fixtures/article-standard-fixture.json
@@ -6,8 +6,8 @@
   "publishedDate": "2016-10-31T12:46:49Z",
   "firstPublishedDate": "2016-10-31T12:46:49Z",
   "id": "bbcddb7a-9f61-11e6-86d5-4e36b35c3550",
-  "genreConcept": null,
-  "brandConcept": null,
+  "genre": null,
+  "brand": null,
   "standfirst": "Prime minister ‘clear in her support’ despite sustained criticism from Brexiters",
   "mainImage": {
     "title": "",

--- a/tests/fixtures/package-fixture.json
+++ b/tests/fixtures/package-fixture.json
@@ -16,7 +16,7 @@
 		"labelType": "none",
 		"sequence": "none"
 	},
-	"brandConcept": {
+	"brand": {
 		"prefLabel": "FT Series"
 	},
 	"design": {

--- a/tests/presenters/package-teaser-presenter.spec.js
+++ b/tests/presenters/package-teaser-presenter.spec.js
@@ -62,7 +62,7 @@ describe('Package Teaser Presenter', () => {
 		})
 
 		it('is Special Report', () => {
-			const content = Object.assign({}, packageFixture, { brandConcept: { prefLabel: 'Special Report' } })
+			const content = Object.assign({}, packageFixture, { brand: { prefLabel: 'Special Report' } })
 			subject = new Presenter(content);
 			expect(subject.genrePrefix).to.equal('Special Report');
 		});

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -189,22 +189,22 @@ describe('Teaser Presenter', () => {
 
 		context('not on a stream page', () => {
 
-			const brandConcept = { brandConcept: { brandConcept: true } };
+			const brand = { brand: { brand: true } };
 			const displayConcept = { displayConcept: { displayConcept: true } };
 
-			it('returns the brandConcept when it exists', () => {
-				const content = Object.assign({}, brandConcept, displayConcept);
+			it('returns the brand when it exists', () => {
+				const content = Object.assign({}, brand, displayConcept);
 				subject = new Presenter(content);
-				expect(subject.teaserConcept.brandConcept).to.be.true;
+				expect(subject.teaserConcept.brand).to.be.true;
 			});
 
-			it('returns the displayConcept when it exists and when brandConcept does not', () => {
+			it('returns the displayConcept when it exists and when brand does not', () => {
 				const content = Object.assign({}, displayConcept);
 				subject = new Presenter(content);
 				expect(subject.teaserConcept.displayConcept).to.be.true;
 			});
 
-			it('returns null if neither the brandConcept nor displayConcept exist', () => {
+			it('returns null if neither the brand nor displayConcept exist', () => {
 				const content = {};
 				subject = new Presenter(content);
 				expect(subject.teaserConcept).to.be.null;
@@ -221,38 +221,43 @@ describe('Teaser Presenter', () => {
 
 		context('genrePrefix', () => {
 
-			const genreConcept = { genreConcept: { prefLabel: 'genre label' } };
-			const brandConcept = { brandConcept: { id: 'ABC' } };
+			const genre = {
+				genre: {
+					id: '61d707b5-6fab-3541-b017-49b72de80772',
+					prefLabel: 'genre label'
+				}
+			};
+			const brand = { brand: { id: 'ABC' } };
 			const streamProperties = { streamProperties: { id: 'ABC'}};
 			const streamPropertiesSpecial = { streamProperties: { directType: 'http://www.ft.com/ontology/SpecialReport'}};
-			const genreConceptSpecial = { genreConcept: { prefLabel: 'Special Report' } };
+			const genreSpecial = { genre: { prefLabel: 'Special Report' } };
 
-			it('returns null if there is no genreConcept', () => {
+			it('returns null if there is no genre', () => {
 				const content = {};
 				subject = new Presenter(content);
 				expect(subject.genrePrefix).to.be.null;
 			});
 
 			it('returns null if there is a genre concept but the display concept is the brand concept', () => {
-				const content = Object.assign({}, genreConcept, brandConcept);
+				const content = Object.assign({}, genre, brand);
 				subject = new Presenter(content);
 				expect(subject.genrePrefix).to.be.null;
 			});
 
 			it('returns the label of the genre concept if it exists and there is no brand concept', () => {
-				const content = Object.assign({}, genreConcept);
+				const content = Object.assign({}, genre);
 				subject = new Presenter(content);
-				expect(subject.genrePrefix).to.equal(genreConcept.genreConcept.prefLabel);
+				expect(subject.genrePrefix).to.equal(genre.genre.prefLabel);
 			});
 
 			it('returns the label of the genre concept if it exists and the brand concept is not displayed', () => {
-				const content = Object.assign({}, genreConcept, brandConcept, streamProperties);
+				const content = Object.assign({}, genre, brand, streamProperties);
 				subject = new Presenter(content);
-				expect(subject.genrePrefix).to.equal(genreConcept.genreConcept.prefLabel);
+				expect(subject.genrePrefix).to.equal(genre.genre.prefLabel);
 			});
 
 			it('returns null when on a special reports stream page', () => {
-				const content = Object.assign({}, genreConceptSpecial, streamPropertiesSpecial);
+				const content = Object.assign({}, genreSpecial, streamPropertiesSpecial);
 				subject = new Presenter(content);
 				expect(subject.genrePrefix).to.be.null;
 			});
@@ -266,24 +271,24 @@ describe('Teaser Presenter', () => {
 
 		context('on a stream page', () => {
 
-			const brandConcept = { brandConcept: { brandConcept: true, id: 'ABC' } };
+			const brand = { brand: { brand: true, id: 'ABC' } };
 			const displayConcept = { displayConcept: { displayConcept: true } };
 			const streamProperties = { streamProperties: { id: 'XYZ'} };
 			const streamPropertiesMatch = { streamProperties: { id: 'ABC'} };
 
-			it('returns the brandConcept if not the same as the streamId', () => {
-				const content = Object.assign({}, streamProperties, brandConcept, displayConcept);
+			it('returns the brand if not the same as the streamId', () => {
+				const content = Object.assign({}, streamProperties, brand, displayConcept);
 				subject = new Presenter(content);
-				expect(subject.teaserConcept.brandConcept).to.be.true;
+				expect(subject.teaserConcept.brand).to.be.true;
 			});
 
-			it('returns the displayConcept if brandConcept is same as streamId', () => {
-				const content = Object.assign({}, streamPropertiesMatch, brandConcept, displayConcept);
+			it('returns the displayConcept if brand is same as streamId', () => {
+				const content = Object.assign({}, streamPropertiesMatch, brand, displayConcept);
 				subject = new Presenter(content);
 				expect(subject.teaserConcept.displayConcept).to.be.true;
 			});
 
-			it('returns the displayConcept if no brandConcept', () => {
+			it('returns the displayConcept if no brand', () => {
 				const content = Object.assign({}, streamPropertiesMatch, displayConcept);
 				subject = new Presenter(content);
 				expect(subject.teaserConcept.displayConcept).to.be.true;
@@ -293,30 +298,30 @@ describe('Teaser Presenter', () => {
 
 		context('when it is both a brand and an opinion / author', () => {
 
-			const brandConcept = { brandConcept: { prefLabel: 'brandName', directType: 'http://www.ft.com/ontology/Brand' } };
-			const brandConceptDupe = { brandConcept: { prefLabel: 'authorName', directType: 'http://www.ft.com/ontology/Brand' } };
-			const authorConcepts = { authorConcepts: [ { prefLabel: 'authorName', directType: 'http://www.ft.com/ontology/Person', id: 'XYZ' } ] };
+			const brand = { brand: { prefLabel: 'brandName', directType: 'http://www.ft.com/ontology/Brand' } };
+			const brandDupe = { brand: { prefLabel: 'authorName', directType: 'http://www.ft.com/ontology/Brand' } };
+			const authors = { authors: [ { prefLabel: 'authorName', directType: 'http://www.ft.com/ontology/Person', id: 'XYZ' } ] };
 			const isOpinion = { isOpinion: true }
 
 			it('returns the brand as genrePrefix and author as displayConcept', () => {
-				const content = Object.assign({}, brandConcept, authorConcepts, isOpinion);
+				const content = Object.assign({}, brand, authors, isOpinion);
 				subject = new Presenter(content);
-				expect(subject.genrePrefix).to.equal(brandConcept.brandConcept.prefLabel);
-				expect(subject.teaserConcept).to.deep.equal(authorConcepts.authorConcepts[0]);
+				expect(subject.genrePrefix).to.equal(brand.brand.prefLabel);
+				expect(subject.teaserConcept).to.deep.equal(authors.authors[0]);
 			});
 
 			it('returns only the author as displayConcept if brand and author are the same', () => {
-				const content = Object.assign({}, brandConceptDupe, authorConcepts, isOpinion);
+				const content = Object.assign({}, brandDupe, authors, isOpinion);
 				subject = new Presenter(content);
 				expect(subject.genrePrefix).to.be.null;
-				expect(subject.teaserConcept).to.deep.equal(authorConcepts.authorConcepts[0]);
+				expect(subject.teaserConcept).to.deep.equal(authors.authors[0]);
 			});
 
 			it('returns brand as display concept and no genre prefix if the author is the same as the stream', () => {
-				const content = Object.assign({ streamProperties: { id: 'XYZ' } }, brandConcept, authorConcepts, isOpinion);
+				const content = Object.assign({ streamProperties: { id: 'XYZ' } }, brand, authors, isOpinion);
 				subject = new Presenter(content);
 				expect(subject.genrePrefix).to.be.null;
-				expect(subject.teaserConcept).to.deep.equal(brandConcept.brandConcept);
+				expect(subject.teaserConcept).to.deep.equal(brand.brand);
 			});
 
 		});
@@ -479,12 +484,26 @@ describe('Teaser Presenter', () => {
 
 		context('author brand combo', () => {
 
-			const brandConcept = { brandConcept: { prefLabel: 'brandName', directType: 'http://www.ft.com/ontology/Brand', attributes: [] } };
-			const authorConcepts = { authorConcepts: [ { prefLabel: 'authorName', attributes: [{key: 'headshot', value:'author-name'} ] } ] };
-			const isOpinion = { isOpinion: true }
+			const brand = {
+				brand: {
+					prefLabel: 'brandName',
+					directType: 'http://www.ft.com/ontology/Brand'
+				}
+			};
+			const authors = {
+				authors: [{
+					prefLabel: 'authorName',
+					headshot: {
+						name: 'author-name'
+					}
+				}]
+			};
+			const isOpinion = {
+				isOpinion: true
+			};
 
 			it('returns a headshot when the author has one', () => {
-				const content = Object.assign({}, brandConcept, authorConcepts, isOpinion);
+				const content = Object.assign({}, brand, authors, isOpinion);
 				subject = new Presenter(content);
 				expect(subject.headshot.url).to.include('author-name');
 			});


### PR DESCRIPTION
 * Authors now returns an `author` concept (which has the headshot deets)
 * a `Brand` can't be a `Person`, so remove code around getting the brand's headshot