### PR TITLE
Adding article's content ID as `[data-content-id]` 

### DIFF
--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -2,6 +2,7 @@
 	<a
 		href="{{{relativeUrl}}}{{{referrerTracking}}}"
 		class="js-teaser-heading-link"
+		data-content-id="{{this.id}}"
 		data-trackable="main-link"
 		{{#ifEquals type 'promoted-content'}}target="_blank"{{/ifEquals}}
 	>


### PR DESCRIPTION
this will be used by the new syndication logic; and will eventually allow us to remove, from `n-teaser`, some of the syndication logic currently contained in there.