### PR TITLE
Un-dev bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "test",
     "tests"
   ],
-  "devDependencies": {
+  "dependencies": {
     "n-ui-foundations": "^2.0.0",
     "o-teaser": "^2.0.0",
     "o-labels": "^3.0.0",


### PR DESCRIPTION
This was causing styling issues downstream.

Before:
<img width="620" alt="1504528941" src="https://user-images.githubusercontent.com/708296/30026990-0395f624-9177-11e7-9c0e-8c3385bdd907.png">

After:
<img width="630" alt="1504528912" src="https://user-images.githubusercontent.com/708296/30026997-0be87a5e-9177-11e7-845b-aa79eceb077a.png">

 🐿 v2.5.16