### PR TITLE
Allow teasers to disable the insitu playable video

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -288,7 +288,8 @@ const TeaserPresenter = class TeaserPresenter {
 		const isLarge = modsDoesInclude('large', this.data.mods) || modsDoesInclude('hero', this.data.mods);
 
 		return Boolean(
-			this.data.flags
+			!this.data.disablePlayableVideo
+			&& this.data.flags
 			&& this.data.flags.insituVideoTeaser
 			&& this.data.type === 'Video'
 			&& ((isTopStory && !isBigStory) || (isHeavy && isLarge))


### PR DESCRIPTION
We have a need for this on myFT because the markup created on the
client side and we don't want to also have to initalise o-video.

This is tied to [this PR in the front page ](https://github.com/Financial-Times/next-front-page/pull/1669)