### PR TITLE
Show genre label for 'Explainer' stories

### DIFF
--- a/secrets.js
+++ b/secrets.js
@@ -57,6 +57,7 @@ module.exports = {
 		'fb491676-5024-3111-a959-1fbce2fbecc1',
 		'ffa10ed8-8bea-11e6-8cb7-e7ada1d123b1',
 		'flags=@root.flags',
-		'e569e23b-0c3e-3d20-8ed0-4c17b8177c05' // opinion concept uuid
+		'e569e23b-0c3e-3d20-8ed0-4c17b8177c05', // opinion concept uuid
+		'b2fa15d1-56b4-3767-8bcd-595b23a5ff22'
 	]
 };

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -52,7 +52,8 @@ const TeaserPresenter = class TeaserPresenter {
 			'9c2af23a-ee61-303f-97e8-2026fb031bd5', // Interview
 			'dc9332a7-453d-3b80-a53d-5a19579d9359', // Q&A
 			'b3ecdf0e-68bb-3303-8773-ec9c05e80234', // Review
-			'3094f0a9-1e1c-3ec3-b7e3-4d4885a826ed' // Special Report
+			'3094f0a9-1e1c-3ec3-b7e3-4d4885a826ed', // Special Report
+			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22' // Explainer
 		];
 		const genreConcept = this.data.genre || this.data.genreConcept;
 		this.genreConcept = (genreConcept && allowedGenres.includes(genreConcept.id)) ? genreConcept : undefined;


### PR DESCRIPTION
 🐿 v2.5.16

[Trello ticket](https://trello.com/c/nM0QFnwz/744-expose-explainer-in-a-genre-on-teasers)

This change prefixes the story title with 'Explainer' prefix:

![image](https://user-images.githubusercontent.com/471250/33840884-10fec49e-de8e-11e7-881d-16edba1e3bbb.png)
