### PR TITLE
modify content.type Video => video

### DIFF
--- a/demos/fixtures/fixtures-video.json
+++ b/demos/fixtures/fixtures-video.json
@@ -5,7 +5,7 @@
     },
     "content": [
         {
-            "type": "Video",
+            "type": "video",
             "id": "b135ff23-b289-3471-9162-71f0a147e7f2",
             "isPremium": false,
             "relativeUrl": "/content/b135ff23-b289-3471-9162-71f0a147e7f2",

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -200,7 +200,7 @@ const TeaserPresenter = class TeaserPresenter {
 			return 'Special Report';
 		}
 
-		if (this.data.type === 'Video') {
+		if (this.data.type === 'video') {
 			return 'Video';
 		}
 
@@ -333,7 +333,7 @@ const TeaserPresenter = class TeaserPresenter {
 			!!this.data.enablePlayableVideo
 			&& this.data.flags
 			&& this.data.flags.insituVideoTeaser
-			&& this.data.type === 'Video'
+			&& this.data.type === 'video'
 			&& ((isTopStory && !isBigStory) || (isHeavy && isLarge))
 		);
 	}

--- a/tests/fixtures/video-fixture.json
+++ b/tests/fixtures/video-fixture.json
@@ -1,5 +1,5 @@
 {
-    "type": "Video",
+    "type": "video",
     "id": "7c24c36f-00e7-3b0b-8620-f91a3bd3b174",
     "title": "Dutch election, Fed rate meeting",
     "standfirst": "A round-up of the big stories being watched by the FT in the coming week",

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -176,8 +176,8 @@ describe('Teaser Presenter', () => {
 				expect(subject.classModifiers).to.deep.equal(['article']);
 			});
 
-			it('returns `video` when content has `type` set to `Video`', () => {
-				const content = {type: 'Video'};
+			it('returns `video` when content has `type` set to `video`', () => {
+				const content = {type: 'video'};
 				subject = new Presenter(content);
 				expect(subject.classModifiers).to.deep.equal(['video']);
 			});


### PR DESCRIPTION
Fix a bug which is not displayed video prefix
https://trello.com/c/xsscnimq/44-video-teasers-on-stream-page-arent-showing-the-video-label