### PR TITLE
don't render dead timestamps

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -239,6 +239,8 @@ const TeaserPresenter = class TeaserPresenter {
 			return {
 				publishedDate: this.data.publishedDate,
 				status: this.timeStatus(),
+				skipPerfAbTesting: !this.data.flags || !this.data.flags.perfDate2,
+				isNewerThanFourHours: this.isNewerThanFourHours(),
 				classModifier: this.timeStatus()
 			};
 		}
@@ -365,6 +367,12 @@ const TeaserPresenter = class TeaserPresenter {
 			}
 		}
 		return status;
+	}
+
+	isNewerThanFourHours () {
+		const now = Date.now();
+		const publishedDate = new Date(this.data.publishedDate).getTime();
+		return (now - publishedDate < 4 * 60 * 60 * 1000);
 	}
 
 	// returns publishedDate, status, classModifier

--- a/templates/partials/timestamp.html
+++ b/templates/partials/timestamp.html
@@ -1,8 +1,11 @@
 {{#with @nTeaserPresenter.timeObject}}
-	<div class="o-teaser__timestamp{{#if classModifier}} o-teaser__timestamp--{{classModifier}}{{/if}}">
-		{{#if status}}
-			<span class="o-teaser__timestamp-prefix">{{status}}</span>
-		{{/if}}
-		<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
-	</div>
+	{{!-- perf A/B testing: don't render if older than 4 hours --}}
+	{{#ifSome isNewerThanFourHours skipPerfAbTesting}}
+		<div class="o-teaser__timestamp{{#if classModifier}} o-teaser__timestamp--{{classModifier}}{{/if}}">
+			{{#if status}}
+				<span class="o-teaser__timestamp-prefix">{{status}}</span>
+			{{/if}}
+			<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
+		</div>
+	{{/ifSome}}
 {{/with}}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -411,6 +411,14 @@ describe('Teaser Presenter', () => {
 				expect(subject.timeStatus()).to.equal('updated');
 			});
 
+			it('is newer than 4 hours', () => {
+				const content = {
+					publishedDate: Date.now() - FIFTY_NINE_MINUTES
+				};
+				subject = new Presenter(content);
+				expect(subject.isNewerThanFourHours()).to.be.true;
+			});
+
 		});
 
 		context('more than an hour since the article published', () => {
@@ -423,6 +431,20 @@ describe('Teaser Presenter', () => {
 				};
 				subject = new Presenter(content);
 				expect(subject.timeStatus()).to.be.null;
+			});
+		});
+
+		context('more than 4 hours since the article published', () => {
+
+			const FOUR_HOURS = 1000 * 60 * 60 * 4;
+
+			it('is not newer than 4 hours', () => {
+				const fourHoursAgo = Date.now() - FOUR_HOURS;
+				const content = {
+					publishedDate: fourHoursAgo
+				};
+				subject = new Presenter(content);
+				expect(subject.isNewerThanFourHours()).to.be.false;
 			});
 		});
 


### PR DESCRIPTION
a performance tweak...

don't render the timestamp if it's older than 4 hours, as it will then get hidden client-side (by o-date JS) anyway

this is behind the flag `perfDate2` for A/B testing to see for any movement with metrics