### PR TITLE
Add accessLevel to ElasticSearch field list

### DIFF
--- a/src/data-model/es.js
+++ b/src/data-model/es.js
@@ -9,7 +9,7 @@ module.exports = [
 	'firstPublishedDate',
 
 	'isEditorsChoice',
-	'isPremium',
+	'accessLevel',
 	'canBeSyndicated',
 
 	'mainImage.title',


### PR DESCRIPTION
This PR contains one of the changes needed to display a "Premium" label in the onward journey of articles.

`next-lure-api` gets a list of ElasticSearch fields from `n-teaser` and it uses it to build a query to the `next-api`. The problem is that this list contains fields that are not used in ElasticSearch, and `premium` is one of those.

We deemed this change to be safe as nothing else seems to be importing the file `data-model/es.js`.

The argument for leaving the name of this file the way it is, is that `next-api` is supposed to be phased out.

[Trello card](https://trello.com/c/xSMx0SDp/777-add-premium-label-on-the-read-next-story-teasers)

 🐿 v2.8.0