### PR TITLE
Adding "type" field to ElasticSearch model

### DIFF
--- a/src/data-model/es.js
+++ b/src/data-model/es.js
@@ -12,6 +12,8 @@ module.exports = [
 	'accessLevel',
 	'canBeSyndicated',
 
+	'type',
+
 	'mainImage.title',
 	'mainImage.description',
 	'mainImage.url',


### PR DESCRIPTION
This change will make the lure-api return an extra `type` field that will let next-article know whether a teaser should be presented as a video (or possibly something else).

At the moment this is not going to cause any visible change in the onward journey or the ribbon, but I still believe that the "type" field needs to be returned, so that if someone makes changes to the way `o-teaser` displays videos, their changes will be reflected.

P.S.: Hope it makes sense!

 🐿 v2.8.0