### PR TITLE
Add alt text for low-vision users

### DIFF
--- a/templates/partials/main-image.html
+++ b/templates/partials/main-image.html
@@ -8,11 +8,11 @@
 			tabindex="-1"
 		>
 			{{#ifEquals lazyLoad false}}
-				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
+				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.title colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
 					{{> n-image/templates/image}}
 				{{/nImagePresenter}}
 			{{else}}
-				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio colspan=colspan position=position widths=widths lazyLoad=true wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
+				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.title colspan=colspan position=position widths=widths lazyLoad=true wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
 					{{> n-image/templates/image}}
 				{{/nImagePresenter}}
 			{{/ifEquals}}


### PR DESCRIPTION
A low vision user reported "There was an image link at the top right of the page, which on mouse hover did not respond with any descriptive label. The only audible response was a URL. "

This provides an alt text description for users who do this, whilst also keeping it hidden from screenreader users as this would be a duplicate link for them.

Tested in Voiceover, JAWS, NVDA

 🐿 v2.8.0