### PR TITLE
Disallow FastFT in meta tag 

### DIFF
--- a/secrets.js
+++ b/secrets.js
@@ -58,6 +58,7 @@ module.exports = {
 		'ffa10ed8-8bea-11e6-8cb7-e7ada1d123b1',
 		'flags=@root.flags',
 		'6da31a37-691f-4908-896f-2829ebe2309e', // opinion concept uuid
-		'b2fa15d1-56b4-3767-8bcd-595b23a5ff22'
+		'b2fa15d1-56b4-3767-8bcd-595b23a5ff22',
+		'5c7592a8-1f0c-11e4-b0cb-b2227cce2b54', // FastFT
 	]
 };

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -56,9 +56,14 @@ const TeaserPresenter = class TeaserPresenter {
 			'3094f0a9-1e1c-3ec3-b7e3-4d4885a826ed', // Special Report
 			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22' // Explainer
 		];
+		const disallowedBrands = [
+			'5c7592a8-1f0c-11e4-b0cb-b2227cce2b54' // FastFT
+		];
 		const genreConcept = this.data.genre || this.data.genreConcept;
 		this.genreConcept = (genreConcept && allowedGenres.includes(genreConcept.id)) ? genreConcept : undefined;
-		this.authorConcept = (this.data.authors || this.data.authorConcepts || [])[0];
+		const authors = (this.data.authors || this.data.authorConcepts || []);
+		this.authorConcept = authors.length === 1 && authors[0];
+		this.brandConcept = this.data.brandConcept && disallowedBrands.includes(this.data.brandConcept.id) ? undefined : this.data.brandConcept;
 	}
 
 	get isOpinion () {
@@ -171,18 +176,19 @@ const TeaserPresenter = class TeaserPresenter {
 			// Use Display concept if Brand concept is the same as stream
 			if (this.data.streamProperties &&
 				this.data.streamProperties.id &&
-				this.data.brandConcept &&
-				this.data.streamProperties.id === this.data.brandConcept.id) {
+				this.brandConcept &&
+				this.data.streamProperties.id === this.brandConcept.id) {
 				return displayConcept || null;
 			}
 			// Use Author Concept if Opinion & Branded unless same as stream
-			if (this.brandAuthorDouble &&
+			if (this.authorConcept &&
+					this.brandAuthorDouble &&
 				(!this.data.streamProperties ||
 				(this.data.streamProperties &&
 				this.data.streamProperties.id !== this.authorConcept.id ))) {
 				return this.authorConcept;
 			}
-			return this.data.brandConcept || displayConcept || null;
+			return this.brandConcept || displayConcept || null;
 		}
 	}
 
@@ -207,17 +213,17 @@ const TeaserPresenter = class TeaserPresenter {
 
 		if (this.brandAuthorDouble) {
 			// dedupe authors who are also brands and where Author = stream
-			if (this.data.brandConcept &&
-				this.data.brandConcept.prefLabel !== this.authorConcept.prefLabel &&
+			if (this.brandConcept &&
+				this.brandConcept.prefLabel !== this.authorConcept.prefLabel &&
 				(!this.data.streamProperties ||
 				(this.data.streamProperties &&
 				this.data.streamProperties.id !== this.authorConcept.id))) {
-				return this.data.brandConcept.prefLabel;
+				return this.brandConcept.prefLabel;
 			}
 		}
 
 		// Do not show a genre prefix against brands
-		if (!this.genreConcept || this.data.brandConcept === this.teaserConcept) {
+		if (!this.genreConcept || this.brandConcept === this.teaserConcept) {
 			return null;
 		}
 

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -57,7 +57,7 @@ const TeaserPresenter = class TeaserPresenter {
 			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22' // Explainer
 		];
 		const disallowedBrands = [
-			// HACK: temporary measure until UPP provides a way to model evolving 
+			// HACK: temporary measure until UPP provides a way to model evolving
 			// stories that start life as FastFT articles.
 			'5c7592a8-1f0c-11e4-b0cb-b2227cce2b54' // FastFT
 		];

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -57,6 +57,8 @@ const TeaserPresenter = class TeaserPresenter {
 			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22' // Explainer
 		];
 		const disallowedBrands = [
+			// HACK: temporary measure until UPP provides a way to model evolving 
+			// stories that start life as FastFT articles.
 			'5c7592a8-1f0c-11e4-b0cb-b2227cce2b54' // FastFT
 		];
 		const genreConcept = this.data.genre || this.data.genreConcept;


### PR DESCRIPTION
This is a temporary fix because now loads of stories will be FastFT because that's how they started out life. However the articles receive subsequent edits and are not really "fast" anymore. The proper fix is modelling this some how in UPP... so just 🌀waiting for that.

Also, only display the author when there's only one author.