### PR TITLE
Revert "Use a better source of data for img alt attributes"

### DIFF
--- a/templates/partials/main-image.html
+++ b/templates/partials/main-image.html
@@ -12,11 +12,11 @@
 			{{/if}}
 		>
 			{{#ifEquals lazyLoad false}}
-				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.mainImage.title colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
+				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.title colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
 					{{> n-image/templates/image}}
 				{{/nImagePresenter}}
 			{{else}}
-				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.mainImage.title colspan=colspan position=position widths=widths lazyLoad=true wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
+				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio alt=@nTeaserPresenter.data.title colspan=colspan position=position widths=widths lazyLoad=true wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}
 					{{> n-image/templates/image}}
 				{{/nImagePresenter}}
 			{{/ifEquals}}


### PR DESCRIPTION
Reverts Financial-Times/n-teaser#179

https://financialtimes.slack.com/archives/C2LMEKC6S/p1522252186000176?thread_ts=1522248481.000017&cid=C2LMEKC6S

> in this case it is the title for the low-vision users who are perceiving that there is a link there and need to know what it links to. It gets hidden from pretty much everyone else. Descriptive text would not help in this case as the user must be able to pick out “here is a link, where will it go