### PR TITLE
Remove `visitedStoriesOnTeaser` flag

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -428,12 +428,6 @@ const TeaserPresenter = class TeaserPresenter {
 		return formattedDuration ? durationData : null;
 	}
 
-	get visited () {
-		if (this.data.flags && this.data.flags.visitedStoriesOnTeaser) {
-			return true;
-		}
-	}
-
 };
 
 module.exports = TeaserPresenter;

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -1,4 +1,4 @@
-<div class="o-teaser__heading {{#if @nTeaserPresenter.visited}}o-teaser__heading--visited{{/if}} js-teaser-heading">
+<div class="o-teaser__heading js-teaser-heading">
 	<a
 		href="{{{relativeUrl}}}{{{referrerTracking}}}"
 		class="js-teaser-heading-link"


### PR DESCRIPTION
The Origami team had created a special class in `o-teaser` to enable us to A/B test the use of a [different shade of black](https://trello.com/c/A1NSJYFR/769-visited-stories) for visited links.

Visited link colours are normally changed using the `:visited` pseudo-selector but that's not suitable for A/B tests.

The test has now been successful, so the "experimental" class [has now been removed](https://github.com/Financial-Times/o-teaser/pull/94) from `o-teaser`.

This PR simply reflects that change in `n-teaser`.

Once this is merged, I wil delete the flag.