### PR TITLE
Option to change data-o-date-format in timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ Example of a teaser with an image;
 The `colspan`, `position` and `widths` arguments are passed on to `n-image` to determine the properties of how the image is displayed in the teaser.
 More details on what is supported by `n-image` can be found in that repository.
 
+By default in timestamp `data-o-date-format="time-ago-limit-4-hours"`, but you can change it by passing `dataDateFormat` argument, e.g.
+```
+{{>n-teaser/templates/heavy widths="[150, 210]" mods=(array 'small') dataDateFormat="time-ago-no-seconds"}}
+```
+
 ### Display options
 Parameters can be passed to suppress some elements of teasers that would otherwise appear.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ By default in timestamp `data-o-date-format="time-ago-limit-4-hours"`, but you c
 ```
 {{>n-teaser/templates/heavy widths="[150, 210]" mods=(array 'small') dataDateFormat="time-ago-no-seconds"}}
 ```
+More about available options for `data-o-date-format` you can find [here](https://github.com/Financial-Times/o-date/blob/f4096227408b3991861c1c6b8f4d409a6c5446cd/main.js#L105).
 
 ### Display options
 Parameters can be passed to suppress some elements of teasers that would otherwise appear.

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -63,8 +63,9 @@ module.exports = {
 			'f38eb0c6-0329-11e7-aa5b-6bb07f5c8e12', // secrets.js:55, tests/fixtures/package-fixture.json:28
 			'f61b93c8-9f5a-11e6-891e-abe238dee8e2', // secrets.js:56, tests/fixtures/article-brand-fixture.json:4|8|38|41
 			'fb491676-5024-3111-a959-1fbce2fbecc1', // secrets.js:57, tests/fixtures/article-package-fixture.json:28|31
-			'6da31a37-691f-4908-896f-2829ebe2309e', // secrets.js:60, src/presenters/teaser-presenter.js:65
-			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22' // secrets.js:61, src/presenters/teaser-presenter.js:57
+			'6da31a37-691f-4908-896f-2829ebe2309e', // secrets.js:60, src/presenters/teaser-presenter.js:76
+			'b2fa15d1-56b4-3767-8bcd-595b23a5ff22', // secrets.js:61, src/presenters/teaser-presenter.js:57
+			'5c7592a8-1f0c-11e4-b0cb-b2227cce2b54' // secrets.js:62, src/presenters/teaser-presenter.js:62
 		]
 	}
 };

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -68,6 +68,10 @@ const TeaserPresenter = class TeaserPresenter {
 		this.brandConcept = this.data.brandConcept && disallowedBrands.includes(this.data.brandConcept.id) ? undefined : this.data.brandConcept;
 	}
 
+	get dataDateFormat () {
+		return this.data.dataDateFormat ? this.data.dataDateFormat : 'time-ago-limit-4-hours';
+	}
+
 	get isOpinion () {
 		return this.data.isOpinion || (this.data.genreConcept && this.data.genreConcept.id === '6da31a37-691f-4908-896f-2829ebe2309e');
 	}

--- a/templates/partials/timestamp.html
+++ b/templates/partials/timestamp.html
@@ -5,7 +5,7 @@
 			{{#if status}}
 				<span class="o-teaser__timestamp-prefix">{{status}}</span>
 			{{/if}}
-			<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
+			<time data-o-component="o-date" class="o-date" data-o-date-format="{{@nTeaserPresenter.dataDateFormat}}" datetime="{{publishedDate}}">{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}</time>
 		</div>
 	{{/ifSome}}
 {{/with}}


### PR DESCRIPTION
## What was done
An opportunity to change the `data-o-date-format` property in the teaser timestamp by passing an argument `dataDateFormat`.