### PR TITLE
accommodate de-janky flag restructure

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -284,7 +284,7 @@ class TeaserPresenter {
 			return {
 				publishedDate: this.data.publishedDate,
 				status: this.timeStatus(),
-				skipPerfAbTesting: !this.data.flags || !(this.data.flags.perfDate2 || this.data.flags.perfJanky),
+				skipPerfAbTesting: !this.data.flags || this.data.flags.perfJanky !== 'calm',
 				isNewerThanFourHours: this.isNewerThanFourHours(),
 				classModifier: this.timeStatus()
 			};


### PR DESCRIPTION
we're restructuring the perfJanky flag to have 3 variants, and we want this performance optimisation to happen with just the 'calm' variant