### PR TITLE
Revert "Use promotional standfirst"

### DIFF
--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -353,7 +353,9 @@ class TeaserPresenter {
 	}
 
 	get displayStandfirst () {
-		return this.data.promotionalStandfirst || this.data.standfirst;
+		//Note: although everywhere else we prefer the promotional version for teasers, we can't do that for standfirsts because the promotionalStandfirst is used for the App Skyline.
+		//So we will only use the promotionalStandfirst if there is no standfirst
+		return this.data.standfirst || this.data.promotionalStandfirst;
 	}
 
 	get displayImage () {

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -750,17 +750,22 @@ describe('Teaser Presenter', () => {
 	describe('display standfirst', () => {
 		const standfirst = { standfirst: 'This is the standfirst' };
 		const promotionalStandfirst = { promotionalStandfirst: 'This is promotional' };
-
 		it('uses the standfirst if no promotional', () => {
 			const content = Object.assign({}, standfirst);
 			subject = new Presenter(content);
 			expect(subject.displayStandfirst).to.equal('This is the standfirst');
 		});
 
-		it('prefers the promotional standfirst if available', () => {
-			const content = Object.assign({}, standfirst, promotionalStandfirst);
+		it('uses the promotional if no standfirst', () => {
+			const content = Object.assign({}, promotionalStandfirst);
 			subject = new Presenter(content);
 			expect(subject.displayStandfirst).to.equal('This is promotional');
+		});
+
+		it('prefers the regular standfirst (because promotionalStandfirst is used for web app skylines)', () => {
+			const content = Object.assign({}, standfirst, promotionalStandfirst);
+			subject = new Presenter(content);
+			expect(subject.displayStandfirst).to.equal('This is the standfirst');
 		});
 	});
 


### PR DESCRIPTION
Reverts Financial-Times/n-teaser#196

Because people are unsure about what they want and they are angry about it