### PR TITLE
Add displayConcept.isDisplayTag to GraphQL queries and test fixtures

### DIFF
--- a/demos/fixtures/fixures-live-blog-closed.json
+++ b/demos/fixtures/fixures-live-blog-closed.json
@@ -59,6 +59,7 @@
       "displayConcept": {
         "prefLabel": "EU Economy",
         "relativeUrl": "/eu-economy",
+        "isDisplayTag": true,
         "latestContent": [
           {
             "type": "Article",

--- a/demos/fixtures/fixures-live-blog.json
+++ b/demos/fixtures/fixures-live-blog.json
@@ -59,6 +59,7 @@
     "displayConcept": {
       "prefLabel": "EU Economy",
       "relativeUrl": "/eu-economy",
+      "isDisplayTag": true,
       "latestContent": [
         {
           "type": "Article",

--- a/src/data-model/es.js
+++ b/src/data-model/es.js
@@ -27,6 +27,7 @@ module.exports = [
 	'displayConcept.prefLabel',
 	'displayConcept.relativeUrl',
 	'displayConcept.directType',
+	'displayConcept.isDisplayTag',
 
 	'brandConcept.id',
 	'brandConcept.prefLabel',

--- a/src/data-model/fragments.js
+++ b/src/data-model/fragments.js
@@ -64,6 +64,7 @@ module.exports = {
 			displayConcept {
 				prefLabel
 				relativeUrl
+				isDisplayTag
 			}
 			...on Video {
 				duration

--- a/tests/fixtures/article-brand-fixture.json
+++ b/tests/fixtures/article-brand-fixture.json
@@ -25,6 +25,7 @@
   "displayConcept": {
     "prefLabel": "FT View",
     "relativeUrl": "/comment/ft-view",
+    "isDisplayTag": true,
     "latestContent": [
       {
         "type": "Article",

--- a/tests/fixtures/article-opinion-author-fixture.json
+++ b/tests/fixtures/article-opinion-author-fixture.json
@@ -28,6 +28,7 @@
   "displayConcept": {
     "prefLabel": "Global politics",
     "relativeUrl": "/topics/themes/Global_politics",
+    "isDisplayTag": true,
     "latestContent": [
       {
         "type": "Article",

--- a/tests/fixtures/article-package-fixture.json
+++ b/tests/fixtures/article-package-fixture.json
@@ -22,7 +22,8 @@
         "id": "3a34141d-e886-3c6f-8985-551ed91e994a",
         "prefLabel": "Equality in workplace",
         "directType": "http://www.ft.com/ontology/Topic",
-        "url": "https://www.ft.com/stream/3a34141d-e886-3c6f-8985-551ed91e994a"
+        "url": "https://www.ft.com/stream/3a34141d-e886-3c6f-8985-551ed91e994a",
+        "isDisplayTag": true
       },
       "brand": {
         "idV1": "fb491676-5024-3111-a959-1fbce2fbecc1",

--- a/tests/fixtures/article-standard-fixture.json
+++ b/tests/fixtures/article-standard-fixture.json
@@ -40,6 +40,7 @@
   "displayConcept": {
     "prefLabel": "UK Politics & Policy",
     "relativeUrl": "/world/uk/politics",
+    "isDisplayTag": true,
     "latestContent": [
       {
         "type": "Article",

--- a/tests/fixtures/video-es-fixture.json
+++ b/tests/fixtures/video-es-fixture.json
@@ -12,7 +12,8 @@
     },
     "displayConcept": {
         "prefLabel": "Week Ahead",
-        "relativeUrl": "/stream/c24d6335-076a-366a-98e2-500bb26401d6"
+        "relativeUrl": "/stream/c24d6335-076a-366a-98e2-500bb26401d6",
+        "isDisplayTag": true
     },
     "attachments": [
       {

--- a/tests/fixtures/video-fixture.json
+++ b/tests/fixtures/video-fixture.json
@@ -12,7 +12,8 @@
     },
     "displayConcept": {
         "prefLabel": "Week Ahead",
-        "relativeUrl": "/stream/c24d6335-076a-366a-98e2-500bb26401d6"
+        "relativeUrl": "/stream/c24d6335-076a-366a-98e2-500bb26401d6",
+        "isDisplayTag": true
     },
     "duration": 270655,
     "formattedDuration": "4:30"


### PR DESCRIPTION
If the GraphQL query doesn't pull in `displayConcept.isDisplayTag` then that data isn't available as part of the diffing logic that is used to purge the front-page. Which means the front page doesn't get purged properly.