### PR TITLE
Teaser testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mocha": "^5.2.0",
     "node-sass": "^4.0.0",
     "npm-prepublish": "^1.2.1",
-    "pa11y-ci": "^2.1.1"
+    "pa11y-ci": "^2.1.1",
+    "sinon": "^6.0.1"
   },
   "config": {},
   "scripts": {

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -309,15 +309,24 @@ class TeaserPresenter {
 
 	// returns title either standard or promotional based on flag
 	get displayTitle () {
+
 		const altTitles = this.data.alternativeTitles;
+
+		if (this.isTeaserTestActive && this.teaserTestVariant === 'variant2') {
+			return this.teaserTestVariantText;
+		}
+				
+		// Support the old 'headlineTesting' mechanism of identifying a test until article-specific testing is available end-to-end. 
 		if (this.data.flags && this.data.flags.headlineTesting && this.data.flags.headlineTesting === 'variant2' && altTitles && (altTitles.promotionalTitleVariant || altTitles.contentPackageTitle)) {
-			return altTitles.promotionalTitleVariant ? altTitles.promotionalTitleVariant : altTitles.contentPackageTitle;
-		} else if (this.data.flags && this.data.flags.teaserUsePromotionalTitle) {
+			return altTitles.promotionalTitleVariant ? altTitles.promotionalTitleVariant: altTitles.contentPackageTitle ;
+		}
+		
+		if (this.data.flags && this.data.flags.teaserUsePromotionalTitle) {
 			if (this.data.promotionalTitle) {
 				return this.data.promotionalTitle;
 			}
 			if (this.data.alternativeTitles && this.data.alternativeTitles.promotionalTitle) {
-				return this.data.alternativeTitles.promotionalTitle;
+				return this.data.alternativeTitles.promotionalTitle ;
 			}
 		}
 		return this.data.title;
@@ -341,6 +350,30 @@ class TeaserPresenter {
 		}
 		return null;
 	}
+
+	// returns true if there is a active headline testing flag created for this story AND a variant headline has been configured 
+	get isTeaserTestActive () {
+		return this.teaserTestVariant && this.teaserTestVariantText;
+	}
+
+	// returns the variant name specified by this teaser's flag 
+	get teaserTestVariant () {
+		const teaserTestFlagName = 'teaser-test-' + this.data.id;
+		if (this.data.flags && this.data.flags[teaserTestFlagName]) {
+			return this.data.flags[teaserTestFlagName] 
+		}
+		return null;
+	}
+
+	// the variant text configured for a teaser
+	get teaserTestVariantText () {
+		const altTitles = this.data.alternativeTitles;
+		if (altTitles && (altTitles.promotionalTitleVariant || altTitles.contentPackageTitle)) {
+			return altTitles.promotionalTitleVariant ? altTitles.promotionalTitleVariant: altTitles.contentPackageTitle ;
+		}
+		return null;
+	}
+
 
 	get isPlayableVideo () {
 		const isTopStory = this.data.template === 'top-story-heavy';

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -309,7 +309,6 @@ class TeaserPresenter {
 
 	// returns title either standard or promotional based on flag
 	get displayTitle () {
-
 		const altTitles = this.data.alternativeTitles;
 
 		if (this.isTeaserTestActive && this.teaserTestVariant === 'variant2') {
@@ -321,14 +320,10 @@ class TeaserPresenter {
 			return altTitles.promotionalTitleVariant ? altTitles.promotionalTitleVariant: altTitles.contentPackageTitle ;
 		}
 		
-		if (this.data.flags && this.data.flags.teaserUsePromotionalTitle) {
-			if (this.data.promotionalTitle) {
-				return this.data.promotionalTitle;
-			}
-			if (this.data.alternativeTitles && this.data.alternativeTitles.promotionalTitle) {
-				return this.data.alternativeTitles.promotionalTitle ;
-			}
+		if (this.isTeaserPromoActive) {
+			return this.teaserPromoTitleText;
 		}
+
 		return this.data.title;
 	}
 
@@ -351,7 +346,23 @@ class TeaserPresenter {
 		return null;
 	}
 
-	// returns true if there is a active headline testing flag created for this story AND a variant headline has been configured 
+	// returns true if there the teaser promo flag is enabled AND teaser promo text has been configured 
+	get isTeaserPromoActive () {
+		return (this.data.flags && this.data.flags.teaserUsePromotionalTitle && this.teaserPromoTitleText) ? true : false;
+	}
+
+	// returns the text configured for a teaserPromo
+	get teaserPromoTitleText () {
+		if (this.data.promotionalTitle) {
+			return this.data.promotionalTitle;
+		}
+		if (this.data.alternativeTitles && this.data.alternativeTitles.promotionalTitle) {
+			return this.data.alternativeTitles.promotionalTitle ;
+		}
+		return null;
+	}
+
+	// returns true if there is a active teaser testing flag created for this story AND a variant headline has been configured 
 	get isTeaserTestActive () {
 		return (this.teaserTestVariant && this.teaserTestVariantText) ? true : false;
 	}
@@ -365,7 +376,7 @@ class TeaserPresenter {
 		return null;
 	}
 
-	// the variant text configured for a teaser
+	// the text configured for a teaser VARIANT
 	get teaserTestVariantText () {
 		const altTitles = this.data.alternativeTitles;
 		if (altTitles && (altTitles.promotionalTitleVariant || altTitles.contentPackageTitle)) {

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -353,7 +353,7 @@ class TeaserPresenter {
 
 	// returns true if there is a active headline testing flag created for this story AND a variant headline has been configured 
 	get isTeaserTestActive () {
-		return this.teaserTestVariant && this.teaserTestVariantText;
+		return (this.teaserTestVariant && this.teaserTestVariantText) ? true : false;
 	}
 
 	// returns the variant name specified by this teaser's flag 

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -10,7 +10,6 @@
 		{{#if @nTeaserPresenter.isTeaserTestActive}}
 			data-trackable-context-teaser-variant="{{{@nTeaserPresenter.teaserTestVariant}}}"
 		{{/if}}
-
 	>
 		{{@nTeaserPresenter.displayTitle}}
 	</a>
@@ -18,6 +17,3 @@
 		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
 	{{/if}}
 </div>
-
-
-{{/if}}

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -6,6 +6,11 @@
 		data-trackable="main-link"
 		{{#ifEquals type 'promoted-content'}}target="_blank"{{/ifEquals}}
 		{{#if @nTeaserPresenter.headlineTestingVariant}}data-trackable-context-headline-variant="{{{@nTeaserPresenter.headlineTestingVariant}}}"{{/if}}
+		
+		{{#if @nTeaserPresenter.isTeaserTestActive}}
+			data-trackable-context-teaser-variant="{{{@nTeaserPresenter.teaserTestVariant}}}"
+		{{/if}}
+
 	>
 		{{@nTeaserPresenter.displayTitle}}
 	</a>
@@ -13,3 +18,6 @@
 		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
 	{{/if}}
 </div>
+
+
+{{/if}}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -650,7 +650,8 @@ describe('Teaser Presenter', () => {
 
 	});
 
-	describe('displayTitle', () => {
+	// todo rip this out when headline testing has been replaced with teaserTesting
+	describe('displayTitle_headlineTesting', () => {
 
 		const promotionalTitle = { promotionalTitle: 'promotional' };
 		const headlineTestingVariants = { alternativeTitles: { contentPackageTitle: 'contentTitle', promotionalTitleVariant: 'variantHeadline' }};
@@ -742,6 +743,111 @@ describe('Teaser Presenter', () => {
 
 		it('returns the title if no flags set', () => {
 			const content = Object.assign({}, title, promotionalTitle);
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+	});
+
+	describe('displayTitle', () => {
+
+		const id = { id: '111111111111-111111-111111-111111-11111111' };
+		const promotionalTitle = { promotionalTitle: 'promotional' };
+		const teaserTestingVariants = { alternativeTitles: { contentPackageTitle: 'contentTitle', promotionalTitleVariant: 'variantHeadline' }};
+		const contentPackageOnly = { alternativeTitles: { contentPackageTitle: 'contentTitle' }};
+		const promoVariantOnly = { alternativeTitles: { promotionalTitleVariant: 'variantHeadline' }};
+		const alternativePromo = { alternativeTitles: { promotionalTitle: 'altPromotional' } };
+		const title = { title: 'title'};
+		const teaserFlagOn = { teaserUsePromotionalTitle: true };
+		const teaserFlagOff = { teaserUsePromotionalTitle: false };
+		const teaserTestVariant = { 'teaser-test-111111111111-111111-111111-111111-11111111': 'variant2' };
+		const teaserTestControl = { 'teaser-test-111111111111-111111-111111-111111-11111111' : 'variant1' };
+
+		it('returns the promoVariant if both teaserTestingVariants are present and teaser testing flag returns variant', () => {
+			const flags = Object.assign({}, teaserTestVariant);
+			const content = Object.assign({}, id, teaserTestingVariants, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('variantHeadline');
+		});
+
+		it('returns the promoVariant if promotionalTitleVariant present and teaser testing flag returns variant', () => {
+			const flags = Object.assign({}, teaserTestVariant);
+			const content = Object.assign({}, { id: '111111111111-111111-111111-111111-11111111'} , promoVariantOnly, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('variantHeadline');
+		});
+
+		it('returns title if promotionalTitleVariant present but teaser testing flag does not exist FOR THAT ARTICLE', () => {
+			const flags = Object.assign({}, teaserTestVariant);
+			const content = Object.assign({id: '222222222222-222222-222222-222222-22222222'}, title, teaserTestingVariants, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+		it('returns the contentPackageHeadline if present and there is no promotionalHeadlineVariant and teaser testing flag returns variant', () => {
+			const flags = Object.assign({}, teaserTestVariant);
+			const content = Object.assign({}, id, contentPackageOnly, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('contentTitle');
+		});
+
+		it('returns the promo title if exists and if the teaser testing flag returns variant but no contentPackageTitle or promotionlHeadlineVariant', () => {
+			const flags = Object.assign({}, teaserTestVariant, teaserFlagOn);
+			const content = Object.assign({}, id, promotionalTitle, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('promotional');
+		});
+
+		it('returns the promo title if teaserTestingVariants exist but teaser testing flag set to control', () => {
+			const flags = Object.assign({}, teaserTestControl, teaserFlagOn);
+			const content = Object.assign({}, id, promotionalTitle, teaserTestingVariants, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('promotional');
+		});
+
+		it('returns the promo title if teaserTestingVariants exist but teaser testing flag not set', () => {
+			const flags = Object.assign({}, teaserFlagOn);
+			const content = Object.assign({}, promotionalTitle, teaserTestingVariants, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('promotional');
+		});
+
+		it('returns the promo title if exists and no teaserTestingVariants exist but altPromo exists', () => {
+			const flags = Object.assign({}, teaserFlagOn, teaserTestVariant);
+			const content = Object.assign({}, id, promotionalTitle, alternativePromo, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('promotional');
+		});
+
+		it('returns the alternative promo title if exists and teaser flag on and teaserTestingVariants and no promo title', () => {
+			const flags = Object.assign({}, teaserTestVariant, teaserFlagOn);
+			const content = Object.assign({}, id, alternativePromo, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('altPromotional');
+		});
+
+		it('returns the title if no teaserTestingVariants and no teaser flag', () => {
+			const flags = Object.assign({}, teaserTestVariant);
+			const content = Object.assign({}, id, title, promotionalTitle, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+		it('returns the title if no teaserTestingVariants, and teaser flag off', () => {
+			const flags = Object.assign({}, teaserTestVariant, teaserFlagOff);
+			const content = Object.assign({}, id, title, promotionalTitle, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+		it('returns the title if no teaserTestingVariants and no promotionalTitle and no alternative promo', () => {
+			const flags = Object.assign({}, teaserFlagOn, teaserTestVariant);
+			const content = Object.assign({}, id, title, {flags});
+			subject = new Presenter(content);
+			expect(subject.displayTitle).to.equal('title');
+		});
+
+		it('returns the title if no flags set innit', () => {
+			const content = Object.assign({}, id, title, promotionalTitle);
 			subject = new Presenter(content);
 			expect(subject.displayTitle).to.equal('title');
 		});

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -853,6 +853,57 @@ describe('Teaser Presenter', () => {
 		});
 	});
 
+	describe('get teaserTestVariant', () => {
+		it('inspects the right flag to see what variant specified for this particular teaser', () => {
+			const flags = {'teaser-test-content-uuid-1': 'variant1', 'teaser-test-content-uuid-2': 'variant2'};
+			subject1 = new Presenter(Object.assign({}, {id: 'content-uuid-1'}, {flags} ));
+			subject2 = new Presenter(Object.assign({}, {id: 'content-uuid-2'}, {flags} ));
+			subject3 = new Presenter(Object.assign({}, {id: 'content-uuid-3'}, {flags} ));  // no flag at all for this teaser
+			expect(subject1.teaserTestVariant).to.equal('variant1');
+			expect(subject2.teaserTestVariant).to.equal('variant2');
+			expect(subject3.teaserTestVariant).to.equal(null);
+		});
+	});
+
+	describe('get teaserTestVariantText', () => {
+		it('uses promotionalTitleVariant if present', () => {
+			const content = Object.assign({}, { alternativeTitles: { promotionalTitleVariant: 'the-promotional-title-variant', contentPackageTitle: 'the-content-package-title'}, title: 'the-title' } );
+			subject = new Presenter(Object.assign({}, content ));
+			expect(subject.teaserTestVariantText).to.equal('the-promotional-title-variant');
+		});
+
+		it('uses contentPackageTitle if promotionalTitleVariant not present', () => {
+			const content = Object.assign({}, { alternativeTitles: { promotionalTitleVariant: null, contentPackageTitle: 'the-content-package-title'}, title: 'the-title' } );
+			subject = new Presenter(Object.assign({}, content ));
+			expect(subject.teaserTestVariantText).to.equal('the-content-package-title');
+		});
+
+		it('returns null if neither alternativeTitle found', () => {
+			const content = Object.assign({}, { title: 'the-title' } );
+			subject = new Presenter(Object.assign({}, content ));
+			expect(subject.teaserTestVariantText).to.equal(null);
+		});
+	});
+
+	describe('isTeaserTestActive', () => {
+		it('returns true if flag is set for that teaser AND variant headlines are configured for that teaser', () => {
+			const flags = {'teaser-test-content-uuid-1': 'some-variant'};
+			const content = Object.assign({}, { id: 'content-uuid-1'}, { alternativeTitles: { promotionalTitleVariant: 'the-promotional-title-variant' }} );
+			subject = new Presenter(Object.assign( {}, content, {flags} ));
+			expect(subject.isTeaserTestActive).to.equal(true);
+		});
+		it('returns false if flag not set for that teaser', () => {
+			const content = Object.assign({}, { id: 'content-uuid-1'}, { alternativeTitles: { promotionalTitleVariant: 'the-promotional-title-variant' }} );
+			subject = new Presenter(Object.assign( {}, content ));
+			expect(subject.isTeaserTestActive).to.equal(false);
+		});
+		it('returns false if no alt titles configured for that teaser', () => {
+			const content = Object.assign({}, { id: 'content-uuid-1'}, { title: 'the-title' } );
+			subject = new Presenter(Object.assign( {}, content ));
+			expect(subject.isTeaserTestActive).to.equal(false);
+		});
+	});
+
 	describe('display standfirst', () => {
 		const standfirst = { standfirst: 'This is the standfirst' };
 		const promotionalStandfirst = { promotionalStandfirst: 'This is promotional' };


### PR DESCRIPTION
Works in conjunction with n-ui changes to support tracking of multiple teasers on homepage with variant headlines configured: https://github.com/Financial-Times/n-ui/pull/1364/