### PR TITLE
Compatibility with o-labels 4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "n-ui-foundations": "^2.5.0",
     "o-teaser": "^2.0.0",
-    "o-labels": "^3.0.0",
+    "o-labels": "^4.0.0",
     "n-image": "^5.0.0"
   },
   "resolutions": {

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -14,6 +14,6 @@
 		{{@nTeaserPresenter.displayTitle}}
 	</a>
 	{{#if isPremium}}
-		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
+		<span class="o-labels o-labels--content-premium o-labels--premium" aria-label="Premium content">Premium</span>
 	{{/if}}
 </div>


### PR DESCRIPTION
Upgrading from o-teaser 2.x.x to 3.x.x breaks the premium label.


Before:

![Screen Shot 2019-04-17 at 16 32 35](https://user-images.githubusercontent.com/616321/56300744-6dcc3480-612e-11e9-94e1-6afe15c98035.png)

After: 

![Screen Shot 2019-04-17 at 16 22 53 1](https://user-images.githubusercontent.com/616321/56300713-63119f80-612e-11e9-8aaf-9732df64aa87.png)
