### PR TITLE
Apply no tabbing for video image links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "tests"
   ],
   "dependencies": {
-    "n-ui-foundations": "^2.5.0",
+    "n-ui-foundations": "^3.0.0",
     "o-teaser": "^2.0.0",
     "o-labels": "^3.0.0",
     "n-image": "^5.0.0"

--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,5 @@
     "o-teaser": "^2.0.0",
     "o-labels": "^3.0.0",
     "n-image": "^5.0.0"
-  },
-  "resolutions": {
-    "n-ui-foundations": "^2.5.0"
   }
 }

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -87,7 +87,7 @@ class TeaserPresenter {
 		) {
 			return true;
 		}
-			return false;
+		return false;
 	}
 
 	// returns all top level class names appropriate for the teaser
@@ -314,7 +314,7 @@ class TeaserPresenter {
 		if (this.isTeaserTestActive && this.teaserTestVariant === 'variant2') {
 			return this.teaserTestVariantText;
 		}
-		
+
 		if (this.isTeaserPromoActive) {
 			return this.teaserPromoTitleText;
 		}
@@ -332,7 +332,7 @@ class TeaserPresenter {
 		return this.data.promotionalImage || this.data.mainImage;
 	}
 
-	// returns true if there the teaser promo flag is enabled AND teaser promo text has been configured 
+	// returns true if there the teaser promo flag is enabled AND teaser promo text has been configured
 	get isTeaserPromoActive () {
 		return (this.data.flags && this.data.flags.teaserUsePromotionalTitle && this.teaserPromoTitleText) ? true : false;
 	}
@@ -348,16 +348,16 @@ class TeaserPresenter {
 		return null;
 	}
 
-	// returns true if there is a active teaser testing flag created for this story AND a variant headline has been configured 
+	// returns true if there is a active teaser testing flag created for this story AND a variant headline has been configured
 	get isTeaserTestActive () {
 		return (this.teaserTestVariant && this.teaserTestVariantText) ? true : false;
 	}
 
-	// returns the variant name specified by this teaser's flag 
+	// returns the variant name specified by this teaser's flag
 	get teaserTestVariant () {
 		const teaserTestFlagName = 'teaser-test-' + this.data.id;
 		if (this.data.flags && this.data.flags[teaserTestFlagName]) {
-			return this.data.flags[teaserTestFlagName] 
+			return this.data.flags[teaserTestFlagName];
 		}
 		return null;
 	}

--- a/src/presenters/teaser-presenter.js
+++ b/src/presenters/teaser-presenter.js
@@ -309,8 +309,6 @@ class TeaserPresenter {
 
 	// returns title either standard or promotional based on flag
 	get displayTitle () {
-		const altTitles = this.data.alternativeTitles;
-
 		if (this.isTeaserTestActive && this.teaserTestVariant === 'variant2') {
 			return this.teaserTestVariantText;
 		}

--- a/templates/partials/main-image.html
+++ b/templates/partials/main-image.html
@@ -4,13 +4,9 @@
 			href="{{{relativeUrl}}}{{{referrerTracking}}}"
 			data-trackable="image"
 			{{#if @nTeaserPresenter.headlineTestingVariant}}data-trackable-context-headline-variant="{{{@nTeaserPresenter.headlineTestingVariant}}}"{{/if}}
-			{{#if @nTeaserPresenter.isVideo}}
-			aria-label="Watch video {{@nTeaserPresenter.displayTitle}}"
-			{{else}}
 			aria-hidden="true"
 			tabindex="-1"
 			title="{{@nTeaserPresenter.data.title}}"
-			{{/if}}
 		>
 			{{#ifEquals lazyLoad false}}
 				{{#nImagePresenter srcSet=@nTeaserPresenter.displayImage.url placeholder=@nTeaserPresenter.displayImage.ratio colspan=colspan position=position widths=widths lazyLoad=false wrapperClasses="o-teaser__image-placeholder" classes="o-teaser__image" sourceParam=@nTeaserPresenter.displayImage.sourceParam}}

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -5,8 +5,8 @@
 		data-content-id="{{this.id}}"
 		data-trackable="main-link"
 		{{#ifEquals type 'promoted-content'}}target="_blank"{{/ifEquals}}
+		{{#if @nTeaserPresenter.isVideo}}aria-label="Watch video {{@nTeaserPresenter.displayTitle}}"{{/if}}
 		{{#if @nTeaserPresenter.headlineTestingVariant}}data-trackable-context-headline-variant="{{{@nTeaserPresenter.headlineTestingVariant}}}"{{/if}}
-		
 		{{#if @nTeaserPresenter.isTeaserTestActive}}
 			data-trackable-context-teaser-variant="{{{@nTeaserPresenter.teaserTestVariant}}}"
 		{{/if}}

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -752,9 +752,9 @@ describe('Teaser Presenter', () => {
 	describe('get teaserTestVariant', () => {
 		it('inspects the right flag to see what variant specified for this particular teaser', () => {
 			const flags = {'teaser-test-content-uuid-1': 'variant1', 'teaser-test-content-uuid-2': 'variant2'};
-			subject1 = new Presenter(Object.assign({}, {id: 'content-uuid-1'}, {flags} ));
-			subject2 = new Presenter(Object.assign({}, {id: 'content-uuid-2'}, {flags} ));
-			subject3 = new Presenter(Object.assign({}, {id: 'content-uuid-3'}, {flags} ));  // no flag at all for this teaser
+			const subject1 = new Presenter(Object.assign({}, {id: 'content-uuid-1'}, {flags} ));
+			const subject2 = new Presenter(Object.assign({}, {id: 'content-uuid-2'}, {flags} ));
+			const subject3 = new Presenter(Object.assign({}, {id: 'content-uuid-3'}, {flags} ));  // no flag at all for this teaser
 			expect(subject1.teaserTestVariant).to.equal('variant1');
 			expect(subject2.teaserTestVariant).to.equal('variant2');
 			expect(subject3.teaserTestVariant).to.equal(null);

--- a/tests/presenters/teaser-presenter.spec.js
+++ b/tests/presenters/teaser-presenter.spec.js
@@ -656,7 +656,7 @@ describe('Teaser Presenter', () => {
 		const promotionalTitle = { promotionalTitle: 'promotional' };
 		const alternativeTitles = { alternativeTitles: { contentPackageTitle: 'contentTitle', promotionalTitleVariant: 'variantHeadline' }};
 		const allTitles = Object.assign({}, title, promotionalTitle, alternativeTitles);
-		
+
 		it('Returns the title if teaserTest inactive and teaserPromo inactive', () => {
 			const content = Object.assign({}, allTitles);
 			subject = new Presenter(content);
@@ -702,7 +702,7 @@ describe('Teaser Presenter', () => {
 	});
 
 	describe('get isTeaserPromoActive', () => {
-		const flagOn =  { teaserUsePromotionalTitle: true };
+		const flagOn = { teaserUsePromotionalTitle: true };
 
 		it('returns true if promo title configured AND flag is on', () => {
 			const flags = Object.assign({}, flagOn);
@@ -731,7 +731,7 @@ describe('Teaser Presenter', () => {
 		const allTitles = Object.assign({}, title, promotionalTitle, alternativeTitles);
 
 		it('uses promotionalTitle if present', () => {
-			const content = Object.assign({},  allTitles );
+			const content = Object.assign({}, allTitles );
 			subject = new Presenter(Object.assign({}, content ));
 			expect(subject.teaserPromoTitleText).to.equal('promotional');
 		});
@@ -743,7 +743,7 @@ describe('Teaser Presenter', () => {
 		});
 
 		it('returns null if neither promoTitle found', () => {
-			const content = Object.assign({}, { title: 'the-title',  alternativeTitles: { promotionalTitleVariant: 'variantHeadline' } } );
+			const content = Object.assign({}, { title: 'the-title', alternativeTitles: { promotionalTitleVariant: 'variantHeadline' } } );
 			subject = new Presenter(Object.assign({}, content ));
 			expect(subject.teaserPromoTitleText).to.equal(null);
 		});


### PR DESCRIPTION
This is part of fixing DAC issues.

Issue
----
Tab focus is not visible on Video image links present under 'Video' heading link.
(Keyboard only users issue)

Solution suggested by DAC
----
Provide a visible outline/border to each interactive element on the page when they receives focus, using CSS.

**However,** it won't be good for Screen reader users if we added the focus outline because
Redundant links should not be provided, as it will be time consuming for the user to navigate to the same link.(image and title link lead to the same page.)
So I'm going to apply no-tabbing for the image links to solve for both users. 

----

<img width="853" alt="Screenshot 2019-06-10 at 17 28 45" src="https://user-images.githubusercontent.com/21194161/59210317-3e253000-8ba5-11e9-89c3-9f228d5a91c1.png">
Tab focus is not visible on Video image links present under 'Video' heading link.
