### PR TITLE
Render premium labels in an o-labels v4 compatible way

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
   ],
   "dependencies": {
     "n-ui-foundations": "^3.0.0",
-    "o-teaser": "^2.0.0",
-    "o-labels": "^3.0.0",
+    "o-teaser": "^3.0.0",
+    "o-labels": "^4.0.0",
     "n-image": "^5.0.0"
   }
 }

--- a/templates/partials/title.html
+++ b/templates/partials/title.html
@@ -14,6 +14,6 @@
 		{{@nTeaserPresenter.displayTitle}}
 	</a>
 	{{#if isPremium}}
-		<span class="o-labels o-labels--premium" aria-label="Premium content">Premium</span>
+		<span class="o-labels o-labels--content-premium" aria-label="Premium content">Premium</span>
 	{{/if}}
 </div>


### PR DESCRIPTION
o-labels 4 has a breaking change in that uses a different classname for premium labels.

https://github.com/Financial-Times/o-labels/blob/master/MIGRATION.md#migrating-from-v3-to-v4

This will be released as a new major version to clearly describe the change.

 🐿 v2.12.4