### PR TITLE
add aria label for categories

### DIFF
--- a/templates/partials/display-concept.html
+++ b/templates/partials/display-concept.html
@@ -6,7 +6,7 @@
 			</span>
 		{{/if}}
 		{{#if @nTeaserPresenter.teaserConcept}}
-			<a href="{{{@nTeaserPresenter.teaserConcept.relativeUrl}}}" class="o-teaser__tag" data-trackable="primary-concept">
+			<a href="{{{@nTeaserPresenter.teaserConcept.relativeUrl}}}" class="o-teaser__tag" data-trackable="primary-concept" aria-label="Category:{{{@nTeaserPresenter.teaserConcept.prefLabel}}}">
 				{{@nTeaserPresenter.teaserConcept.prefLabel}}
 			</a>
 		{{/if}}


### PR DESCRIPTION
so that the screen reader is slightly more verbose about where, for example, the link `Argentina` leads us, we now give it an aria-label which will say 'link, Category: Argentina'.  This should make it clearer that the link takes you to `ft.com/argentina`

 🐿 v2.12.4